### PR TITLE
enhanced: #64 [debug log] print current space in session before switch

### DIFF
--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
@@ -210,14 +210,16 @@ public class MapperProxy {
     ResultSet result = null;
     String proxyClass = null;
     String proxyMethod = null;
+    String localSessionSpace = null;
     try {
+      localSession = ENV.getDispatcher().poll();
       if (log.isDebugEnabled()) {
         StackTraceElement stackTraceElement = Thread.currentThread().getStackTrace()[6];
         proxyClass = stackTraceElement.getClassName();
         proxyMethod = stackTraceElement.getMethodName();
+        localSessionSpace = localSession.getCurrentSpace();
       }
 
-      localSession = ENV.getDispatcher().poll();
       String currentSpace = getSpace(cm, mm);
       gql = qlWithSpace(localSession, gql, currentSpace);
       session = localSession.getSession();
@@ -231,8 +233,14 @@ public class MapperProxy {
     } catch (Exception e) {
       throw new QueryException("数据查询失败：" + e.getMessage(), e);
     } finally {
-      log.debug("\n\t- proxyMethod: {}#{} \n\t- nGql：{} \n\t - params: {}\n\t - result：{}",
-          proxyClass, proxyMethod, gql, params, result);
+      if (log.isDebugEnabled()) {
+        log.debug("\n\t- proxyMethod: {}#{}"
+                + "\n\t- session space: {}"
+                + "\n\t- nGql：{}"
+                + "\n\t- params: {}"
+                + "\n\t- result：{}",
+            proxyClass, proxyMethod, localSessionSpace, gql, params, result);
+      }
       if (localSession != null) {
         ENV.getDispatcher().offer(localSession);
       }


### PR DESCRIPTION
If the space in the session is the same as which used by the dao method,
ngbatis will not **switch the spaces** [`USE space`] again.

So need to print the current space in the console for debugging.