### PR TITLE
fix #78 use space and gql are executed together incorrect in 3.3.0

### DIFF
--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
@@ -17,8 +17,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.nebula.contrib.ngbatis.ArgNameFormatter;
 import org.nebula.contrib.ngbatis.Env;
 import org.nebula.contrib.ngbatis.ResultResolver;
@@ -229,8 +227,8 @@ public class MapperProxy {
       autoSwitch = qlAndSpace[0] == null ? "" : qlAndSpace[0];
       session = localSession.getSession();
       result = session.executeWithParameter(gql, params);
+      localSession.setCurrentSpace(result.getSpaceName());
       if (result.isSucceeded()) {
-        setNewSpace(localSession, gql, currentSpace);
         return result;
       } else {
         throw new QueryException(" 数据查询失败" + result.getErrorMessage());
@@ -266,27 +264,6 @@ public class MapperProxy {
     }
     qlAndSpace[1] = String.format("\n\t\t%s", gql);
     return qlAndSpace;
-  }
-
-  private static void setNewSpace(LocalSession localSession, String gql, String currentSpace) {
-    String lastSpace = findLastSpaceFromGql(gql);
-    if (lastSpace == null) {
-      localSession.setCurrentSpace(currentSpace);
-    } else {
-      localSession.setCurrentSpace(lastSpace);
-    }
-  }
-
-  private static final String PATTERN = "(?s).*(\\bUSE\\s+(\\S+);).*";
-
-  private static String findLastSpaceFromGql(String gql) {
-    Pattern r = Pattern.compile(PATTERN, Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
-    Matcher m = r.matcher(gql);
-    if (!m.matches()) {
-      return null;
-    } else {
-      return m.group(2);
-    }
   }
 
   /**

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ResultSetUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ResultSetUtil.java
@@ -8,13 +8,12 @@ import static org.nebula.contrib.ngbatis.utils.ReflectUtil.castNumber;
 import static org.nebula.contrib.ngbatis.utils.ReflectUtil.getPkField;
 
 import com.vesoft.nebula.ErrorCode;
-import com.vesoft.nebula.client.graph.data.ResultSet;
 import com.vesoft.nebula.client.graph.data.DateTimeWrapper;
 import com.vesoft.nebula.client.graph.data.DateWrapper;
 import com.vesoft.nebula.client.graph.data.Node;
 import com.vesoft.nebula.client.graph.data.Relationship;
+import com.vesoft.nebula.client.graph.data.ResultSet;
 import com.vesoft.nebula.client.graph.data.ValueWrapper;
-
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -248,7 +247,7 @@ public class ResultSetUtil {
       return false;
     }
     for (ErrorCode code : errorCodes) {
-      if (resultSet.getErrorCode() == code.getValue()){
+      if (resultSet.getErrorCode() == code.getValue()) {
         return true;
       }
     }


### PR DESCRIPTION
@llinzhe
When switch space is required, will execute twice , 
one is `USE space` , another is normal nGQL