### PR TITLE
feat #103 #118 support. provide default data structure for edge \ vertex \ path \ sub-graph, and their result handler.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build with Maven
       run: |
-        mvn -B package
+        mvn -B install
         cd ngbatis-demo
         mvn -B compile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This source code is licensed under Apache 2.0 License.
 -->
 
 # 1.1.2-SNAPSHOT
+- feat: provide default data structure for edge \ vertex \ path \ sub-graph, and their result handler. #103 #118
+- feat: NebulaDaoBasic shortest path support. #118
 - feat: ng.valueFmt support escape ( default true ). Use `ValueFmtFn.setEscape( false );` to disable this feature.
 
 # 1.1.1

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/TestRepository.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/TestRepository.java
@@ -8,6 +8,9 @@ import com.vesoft.nebula.client.graph.data.ResultSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.nebula.contrib.ngbatis.models.data.NgEdge;
+import org.nebula.contrib.ngbatis.models.data.NgSubgraph;
+import org.nebula.contrib.ngbatis.models.data.NgVertex;
 import org.nebula.contrib.ngbatis.proxy.NebulaDaoBasic;
 import org.nebula.contrib.ngbatis.utils.Page;
 import org.springframework.data.repository.query.Param;
@@ -65,5 +68,11 @@ public interface TestRepository extends NebulaDaoBasic<Person, String> {
   Integer testSpaceSwitchStep2();
 
   void insertWithTimestamp(@Param("person") Person person);
+
+  List<NgVertex<String>> selectVertexes();
+  
+  List<NgEdge<String>> selectEdges();
+  
+  List<NgSubgraph<String>> selectSubgraph(); 
 
 }

--- a/ngbatis-demo/src/main/resources/mapper/TestRepository.xml
+++ b/ngbatis-demo/src/main/resources/mapper/TestRepository.xml
@@ -113,6 +113,24 @@
           ${ ng.valueFmt(person.birthday) }
         );
     </insert>
+    
+    <select id="selectVertexes" resultType="org.nebula.contrib.ngbatis.models.data.NgVertex">
+        MATCH (n)
+        RETURN n
+        LIMIT 10
+    </select>
+    
+    <select id="selectEdges" resultType="org.nebula.contrib.ngbatis.models.data.NgEdge">
+        MATCH (n: person)-[r]->(n2: person) 
+        RETURN r 
+        LIMIT 10
+    </select>
+    
+    <select id="selectSubgraph" resultType="org.nebula.contrib.ngbatis.models.data.NgSubgraph">
+        GET SUBGRAPH WITH PROP 3 STEPS FROM "叶小南"
+        BOTH like
+        YIELD VERTICES AS nodes, EDGES AS relationships
+    </select>
 
 </mapper>
 

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NebulaBasicDaoTests.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NebulaBasicDaoTests.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.util.Assert;
+import org.nebula.contrib.ngbatis.models.data.NgPath;
 import org.nebula.contrib.ngbatis.utils.Page;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -459,6 +460,12 @@ public class NebulaBasicDaoTests {
   public void startNode() {
     Person whoIsStartForTest = repository.startNode(Like.class, "易小海");
     System.out.println(JSON.toJSONString(whoIsStartForTest));
+  }
+  
+  @Test
+  public void shortestPath() {
+    List<NgPath<String>> ngPaths = repository.shortestPath("吴小极", "刘小洲");
+    System.out.println(JSON.toJSONString(ngPaths));
   }
   // endregion
 

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NgbatisDemoApplicationTests.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NgbatisDemoApplicationTests.java
@@ -12,6 +12,9 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.util.Assert;
+import org.nebula.contrib.ngbatis.models.data.NgEdge;
+import org.nebula.contrib.ngbatis.models.data.NgSubgraph;
+import org.nebula.contrib.ngbatis.models.data.NgVertex;
 import org.nebula.contrib.ngbatis.utils.Page;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -137,6 +140,24 @@ class NgbatisDemoApplicationTests {
   public void selectPersonLikePersonLimit1() {
     PersonLikePerson nrn2 = repository.selectPersonLikePersonLimit1();
     System.out.println(JSON.toJSONString(nrn2));
+  }
+
+  @Test
+  public void selectVertexes() {
+    List<NgVertex<String>> ngVertices = repository.selectVertexes();
+    System.out.println(JSON.toJSONString(ngVertices));
+  }
+
+  @Test
+  public void selectEdges() {
+    List<NgEdge<String>> ngEdges = repository.selectEdges();
+    System.out.println(JSON.toJSONString(ngEdges));
+  }
+
+  @Test
+  public void selectSubgraph() {
+    List<NgSubgraph<String>> ngSubgraphs = repository.selectSubgraph();
+    System.out.println(JSON.toJSONString(ngSubgraphs));
   }
 
   @Test

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/AbstractResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/AbstractResultHandler.java
@@ -5,6 +5,7 @@ package org.nebula.contrib.ngbatis.handler;
 // This source code is licensed under Apache 2.0 License.
 
 import static org.nebula.contrib.ngbatis.utils.ReflectUtil.isBasicType;
+import static org.nebula.contrib.ngbatis.utils.ReflectUtil.typeToClass;
 
 import com.vesoft.nebula.client.graph.data.ResultSet;
 import java.lang.reflect.ParameterizedType;
@@ -47,8 +48,8 @@ public abstract class AbstractResultHandler<T, Z> implements ResultHandler<T, Z>
     if (typeParameters != null && typeParameters.length == 2) {
       try {
         addHandler(
-            Class.forName(typeParameters[0].getTypeName()),
-            Class.forName(typeParameters[1].getTypeName())
+            typeToClass(typeParameters[0]),
+            typeToClass(typeParameters[1])
         );
       } catch (ClassNotFoundException e) {
         e.printStackTrace();

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/CollectionNgEdgeResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/CollectionNgEdgeResultHandler.java
@@ -1,0 +1,37 @@
+package org.nebula.contrib.ngbatis.handler;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.data.ResultSet.Record;
+import java.util.Collection;
+import org.nebula.contrib.ngbatis.models.data.NgEdge;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert the edge data from ResultSet to collection of NgEdge.
+ * @author yeweicheng
+ * @since 2023-01-07 4:53
+ *   <br> Now is history!
+ */
+@Component
+public class CollectionNgEdgeResultHandler extends AbstractResultHandler<Collection, NgEdge<?>> {
+  
+  @Autowired private NgEdgeResultHandler singleHandler;
+  
+  @Override
+  public Collection handle(Collection newResult, ResultSet result, Class resultType)
+      throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+    int rowSize = result.rowsSize();
+    for (int i = 0; i < rowSize; i++) {
+      Record row = result.rowValues(i);
+      NgEdge<?> vertex = new NgEdge<>();
+      vertex = singleHandler.handle(vertex, row);
+      newResult.add(vertex);
+    }
+    return newResult;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/CollectionNgPathResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/CollectionNgPathResultHandler.java
@@ -1,0 +1,37 @@
+package org.nebula.contrib.ngbatis.handler;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.data.ResultSet.Record;
+import java.util.Collection;
+import org.nebula.contrib.ngbatis.models.data.NgPath;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert the path data from ResultSet to collection of NgPath.
+ * @author yeweicheng
+ * @since 2023-01-07 4:57
+ *   <br> Now is history!
+ */
+@Component
+public class CollectionNgPathResultHandler extends AbstractResultHandler<Collection, NgPath<?>> {
+
+  @Autowired private NgPathResultHandler singleHandler;
+
+  @Override
+  public Collection handle(Collection newResult, ResultSet result, Class resultType)
+      throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+    int rowsSize = result.rowsSize();
+    for (int i = 0; i < rowsSize; i++) {
+      Record row = result.rowValues(i);
+      NgPath<?> ngPath = new NgPath<>();
+      ngPath = singleHandler.handle(ngPath, row);
+      newResult.add(ngPath);
+    }
+    return newResult;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/CollectionNgSubgraphResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/CollectionNgSubgraphResultHandler.java
@@ -1,0 +1,38 @@
+package org.nebula.contrib.ngbatis.handler;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.data.ResultSet.Record;
+import java.util.Collection;
+import org.nebula.contrib.ngbatis.models.data.NgSubgraph;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert the subgraph data from ResultSet to collection of NgSubgraph.
+ * @author yeweicheng
+ * @since 2023-01-07 4:57
+ *   <br> Now is history!
+ */
+@Component
+public class CollectionNgSubgraphResultHandler 
+    extends AbstractResultHandler<Collection, NgSubgraph<?>> {
+
+  @Autowired private NgSubgraphResultHandler singleHandler;
+
+  @Override
+  public Collection handle(Collection newResult, ResultSet result, Class resultType)
+      throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+    int rowSize = result.rowsSize();
+    for (int i = 0; i < rowSize; i++) {
+      Record row = result.rowValues(i);
+      NgSubgraph<?> subgraph = new NgSubgraph<>();
+      subgraph = singleHandler.handle(subgraph, row);
+      newResult.add(subgraph);
+    }
+    return newResult;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/CollectionNgVertexResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/CollectionNgVertexResultHandler.java
@@ -1,0 +1,38 @@
+package org.nebula.contrib.ngbatis.handler;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.data.ResultSet.Record;
+import java.util.Collection;
+import org.nebula.contrib.ngbatis.models.data.NgVertex;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert the vertex data from ResultSet to collection of NgVertex.
+ * @author yeweicheng
+ * @since 2023-01-07 4:57
+ *   <br> Now is history!
+ */
+@Component
+public class CollectionNgVertexResultHandler 
+    extends AbstractResultHandler<Collection, NgVertex<?>> {
+
+  @Autowired private NgVertexResultHandler singleHandler;
+
+  @Override
+  public Collection handle(Collection newResult, ResultSet result, Class resultType)
+      throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+    int rowSize = result.rowsSize();
+    for (int i = 0; i < rowSize; i++) {
+      Record row = result.rowValues(i);
+      NgVertex<?> vertex = new NgVertex<>();
+      vertex = singleHandler.handle(vertex, row);
+      newResult.add(vertex);
+    }
+    return newResult;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/NgEdgeResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/NgEdgeResultHandler.java
@@ -1,0 +1,59 @@
+package org.nebula.contrib.ngbatis.handler;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import static org.nebula.contrib.ngbatis.utils.ResultSetUtil.edgePropsToMap;
+import static org.nebula.contrib.ngbatis.utils.ResultSetUtil.getValue;
+
+import com.vesoft.nebula.client.graph.data.Relationship;
+import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.data.ResultSet.Record;
+import com.vesoft.nebula.client.graph.data.ValueWrapper;
+import java.io.UnsupportedEncodingException;
+import org.nebula.contrib.ngbatis.exception.ResultHandleException;
+import org.nebula.contrib.ngbatis.models.data.NgEdge;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert the edge data from ResultSet to NgVertex. 
+ * @author yeweicheng
+ * @since 2023-01-07 4:54
+ *   <br> Now is history!
+ */
+@Component
+public class NgEdgeResultHandler extends AbstractResultHandler<NgEdge<?>, NgEdge<?>> {
+
+  @Override
+  public NgEdge<?> handle(NgEdge<?> newResult, ResultSet result, Class resultType)
+      throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+    Record row = result.rowValues(0);
+    return handle(newResult, row);
+  }
+  
+  public NgEdge<?> handle(NgEdge<?> newResult, Record row) {
+    ValueWrapper relationship = row.get(0);
+    return handle(newResult, relationship);
+  }
+  
+  public NgEdge<?> handle(NgEdge<?> newResult, ValueWrapper relationshipValueWrapper) {
+    try {
+      Relationship relationship = relationshipValueWrapper.asRelationship();
+      
+      newResult.setEdgeName(relationship.edgeName());
+  
+      long ranking = relationship.ranking();
+      newResult.setRank(ranking);
+  
+      newResult.setSrcID(getValue(relationship.srcId()));
+      newResult.setDstID(getValue(relationship.dstId()));
+  
+      newResult.setProperties(edgePropsToMap(relationship));
+      return newResult;
+    } catch (UnsupportedEncodingException e) {
+      throw new ResultHandleException(
+          String.format("%s : %s", e.getClass().toString(), e.getMessage()));
+    }
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/NgPathResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/NgPathResultHandler.java
@@ -1,0 +1,49 @@
+package org.nebula.contrib.ngbatis.handler;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import com.vesoft.nebula.client.graph.data.PathWrapper;
+import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.data.ResultSet.Record;
+import org.nebula.contrib.ngbatis.models.data.NgPath;
+import org.nebula.contrib.ngbatis.utils.ResultSetUtil;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert the path data from ResultSet to NgPath. 
+ * @author yeweicheng
+ * @since 2023-01-07 4:54
+ *   <br> Now is history!
+ */
+@Component
+public class NgPathResultHandler extends AbstractResultHandler<NgPath<?>, NgPath<?>> {
+
+  @Override
+  public NgPath<?> handle(NgPath<?> newResult, ResultSet result, Class resultType)
+      throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+    Record record = result.rowValues(0);
+    return handle(newResult, record);
+  }
+
+  public NgPath<?> handle(NgPath<?> newResult, Record record) {
+    PathWrapper pathWrapper = ResultSetUtil.getValue(record.values().get(0));
+    
+    pathWrapper.getRelationships().forEach(relationship -> {
+      NgPath.Relationship ngRelationship = new NgPath.Relationship();
+      long ranking = relationship.ranking();
+      Object srcId = ResultSetUtil.getValue(relationship.srcId());
+      Object dstId = ResultSetUtil.getValue(relationship.dstId());
+      String edgeName = relationship.edgeName();
+      
+      ngRelationship.setRank(ranking);
+      ngRelationship.setSrcID(srcId);
+      ngRelationship.setDstID(dstId);
+      ngRelationship.setEdgeName(edgeName);
+      
+      newResult.getRelationships().add(ngRelationship);
+    });
+    return newResult;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/NgSubgraphResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/NgSubgraphResultHandler.java
@@ -1,0 +1,60 @@
+package org.nebula.contrib.ngbatis.handler;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.data.ResultSet.Record;
+import com.vesoft.nebula.client.graph.data.ValueWrapper;
+import java.util.List;
+import org.nebula.contrib.ngbatis.models.data.NgEdge;
+import org.nebula.contrib.ngbatis.models.data.NgSubgraph;
+import org.nebula.contrib.ngbatis.models.data.NgVertex;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert the subgraph data from ResultSet to NgSubgraph. 
+ * @author yeweicheng
+ * @since 2023-01-07 4:55
+ *   <br> Now is history!
+ */
+@Component
+public class NgSubgraphResultHandler extends AbstractResultHandler<NgSubgraph<?>, NgSubgraph<?>> {
+
+  @Autowired private NgEdgeResultHandler edgeResultHandler;
+  @Autowired private NgVertexResultHandler vertexResultHandler;
+  
+  @Override
+  public NgSubgraph<?> handle(NgSubgraph<?> newResult, ResultSet result, Class resultType)
+      throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+    Record row = result.rowValues(0);
+    return handle(newResult, row);
+  }
+
+  public NgSubgraph<?> handle(NgSubgraph<?> newResult, Record row) {
+    ValueWrapper nodes = row.get("nodes");
+    if (nodes != null) {
+      List<ValueWrapper> nodesValueWrapper = nodes.asList();
+      nodesValueWrapper.forEach(nodeValueWrapper -> {
+        List vertexes = newResult.getVertexes();
+        NgVertex<?> vertex = new NgVertex<>();
+        vertex = vertexResultHandler.handle(vertex, nodeValueWrapper);
+        vertexes.add(vertex);
+      });
+    }
+
+    ValueWrapper relationships = row.get("relationships");
+    if (relationships != null) {
+      List<ValueWrapper> edgesValueWrapper = relationships.asList();
+      edgesValueWrapper.forEach(edgeValueWrapper -> {
+        List edges = newResult.getEdges();
+        NgEdge<?> edge = new NgEdge<>();
+        edge = edgeResultHandler.handle(edge, edgeValueWrapper);
+        edges.add(edge);
+      });
+    }
+    return newResult;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/NgVertexResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/NgVertexResultHandler.java
@@ -1,0 +1,56 @@
+package org.nebula.contrib.ngbatis.handler;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import static org.nebula.contrib.ngbatis.utils.ResultSetUtil.nodePropsToMap;
+
+import com.vesoft.nebula.client.graph.data.Node;
+import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.data.ResultSet.Record;
+import com.vesoft.nebula.client.graph.data.ValueWrapper;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import org.nebula.contrib.ngbatis.exception.ResultHandleException;
+import org.nebula.contrib.ngbatis.models.data.NgVertex;
+import org.nebula.contrib.ngbatis.utils.ResultSetUtil;
+import org.springframework.stereotype.Component;
+
+/**
+ * Convert the vertex data from ResultSet to NgVertex. 
+ * @author yeweicheng
+ * @since 2023-01-07 4:55
+ *   <br> Now is history!
+ */
+@Component
+public class NgVertexResultHandler extends AbstractResultHandler<NgVertex<?>, NgVertex<?>> {
+
+  @Override
+  public NgVertex<?> handle(NgVertex<?> newResult, ResultSet result, Class resultType)
+      throws NoSuchFieldException, IllegalAccessException, InstantiationException {
+    Record row = result.rowValues(0);
+    return handle(newResult, row);
+  }
+
+  public NgVertex<?> handle(NgVertex<?> newResult, Record row) {
+    ValueWrapper node = row.get(0);
+    handle(newResult, node);
+    return newResult;
+  }
+  
+  public NgVertex<?> handle(NgVertex<?> newResult, ValueWrapper nodeValueWrapper) {
+    try {
+      Node node = nodeValueWrapper.asNode();
+      ValueWrapper id = node.getId();
+      newResult.setVid(ResultSetUtil.getValue(id));
+      List<String> tags = node.tagNames();
+      newResult.setTags(tags);
+      newResult.setProperties(nodePropsToMap(node));
+      return newResult;
+    } catch (UnsupportedEncodingException e) {
+      throw new ResultHandleException(
+          String.format("%s : %s", e.getClass().toString(), e.getMessage()));
+    }
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/models/data/NgEdge.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/data/NgEdge.java
@@ -1,0 +1,71 @@
+package org.nebula.contrib.ngbatis.models.data;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.util.Map;
+
+/**
+ * A common pojo for edges.
+ * 为【边】数据定义的一个通用数据类型，对业务代码存在入侵，慎用。
+ * @author yeweicheng
+ * @since 2023-01-07 4:20
+ *   <br> Now is history!
+ */
+public class NgEdge<I> {
+  private String type;
+  private I srcID;
+  private I dstID;
+  private Long rank;
+  private String edgeName;
+  private Map<String, Object> properties;
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public I getSrcID() {
+    return srcID;
+  }
+
+  public void setSrcID(I srcID) {
+    this.srcID = srcID;
+  }
+
+  public I getDstID() {
+    return dstID;
+  }
+
+  public void setDstID(I dstID) {
+    this.dstID = dstID;
+  }
+
+  public Long getRank() {
+    return rank;
+  }
+
+  public void setRank(Long rank) {
+    this.rank = rank;
+  }
+
+  public String getEdgeName() {
+    return edgeName;
+  }
+
+  public void setEdgeName(String edgeName) {
+    this.edgeName = edgeName;
+  }
+
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, Object> properties) {
+    this.properties = properties;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/models/data/NgPath.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/data/NgPath.java
@@ -1,0 +1,69 @@
+package org.nebula.contrib.ngbatis.models.data;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A common pojo for paths.
+ * 为【路径】数据定义的一个通用数据类型，对业务代码存在入侵，慎用。
+ * @author yeweicheng
+ * @since 2023-01-07 4:23
+ *   <br> Now is history!
+ */
+public class NgPath<I> {
+  
+  private List<Relationship<I>> relationships = new ArrayList<>();
+
+  public List<Relationship<I>> getRelationships() {
+    return relationships;
+  }
+
+  public void setRelationships(
+      List<Relationship<I>> relationships) {
+    this.relationships = relationships;
+  }
+
+  public static class Relationship<I> {
+    private I dstID;
+    private String edgeName;
+    private Long rank;
+    private I srcID;
+
+    public I getDstID() {
+      return dstID;
+    }
+
+    public void setDstID(I dstID) {
+      this.dstID = dstID;
+    }
+
+    public String getEdgeName() {
+      return edgeName;
+    }
+
+    public void setEdgeName(String edgeName) {
+      this.edgeName = edgeName;
+    }
+
+    public Long getRank() {
+      return rank;
+    }
+
+    public void setRank(Long rank) {
+      this.rank = rank;
+    }
+
+    public I getSrcID() {
+      return srcID;
+    }
+
+    public void setSrcID(I srcID) {
+      this.srcID = srcID;
+    }
+  }
+  
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/models/data/NgSubgraph.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/data/NgSubgraph.java
@@ -1,0 +1,36 @@
+package org.nebula.contrib.ngbatis.models.data;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A common pojo for subgraph.
+ * 为【子图】数据定义的一个通用数据类型，对业务代码存在入侵，慎用。
+ * @author yeweicheng
+ * @since 2023-01-07 4:46
+ *   <br> Now is history!
+ */
+public class NgSubgraph<I> {
+  private List<NgVertex<I>> vertexes = new ArrayList<>();
+  private List<NgEdge<I>> edges = new ArrayList<>();
+
+  public List<NgVertex<I>> getVertexes() {
+    return vertexes;
+  }
+
+  public void setVertexes(List<NgVertex<I>> vertexes) {
+    this.vertexes = vertexes;
+  }
+
+  public List<NgEdge<I>> getEdges() {
+    return edges;
+  }
+
+  public void setEdges(List<NgEdge<I>> edges) {
+    this.edges = edges;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/models/data/NgVertex.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/data/NgVertex.java
@@ -1,0 +1,58 @@
+package org.nebula.contrib.ngbatis.models.data;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A common pojo for vertexes.
+ * 为【点】数据定义的一个通用数据类型，对业务代码存在入侵，慎用。
+ * @author yeweicheng
+ * @since 2023-01-07 4:23
+ *   <br> Now is history!
+ */
+public class NgVertex<I> {
+  private String type;
+  private I vid;
+  private List<String> tags;
+  private Map<String, Object> properties;
+  
+  public String tag() {
+    return tags.get(0);
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public I getVid() {
+    return vid;
+  }
+
+  public void setVid(I vid) {
+    this.vid = vid;
+  }
+
+  public List<String> getTags() {
+    return tags;
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+  public Map<String, Object> getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Map<String, Object> properties) {
+    this.properties = properties;
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.nebula.contrib.ngbatis.exception.QueryException;
 import org.nebula.contrib.ngbatis.models.ClassModel;
 import org.nebula.contrib.ngbatis.models.MethodModel;
+import org.nebula.contrib.ngbatis.models.data.NgPath;
 import org.nebula.contrib.ngbatis.utils.Page;
 import org.springframework.data.repository.query.Param;
 
@@ -441,6 +442,20 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
     return (E) proxy(daoType, returnType, cqlTpl,
       new Class[]{Class.class, Class.class, Serializable.class}, startVertexName, edgeName,
       endId);
+  }
+
+  /**
+   * Find the shortest path by srcId and dstId.
+   * @param srcId the start node's id
+   * @param dstId the end node's id
+   * @return Shortest path list. 
+   */
+  default List<NgPath<I>> shortestPath(@Param("srcId") I srcId, @Param("dstId") I dstId) {
+    MethodModel methodModel = getMethodModel();
+    methodModel.setReturnType(Collection.class);
+    methodModel.setResultType(NgPath.class);
+    ClassModel classModel = getClassModel(this.getClass());
+    return (List<NgPath<I>>) MapperProxy.invoke(classModel, methodModel, srcId, dstId);
   }
   // endregion
 

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
@@ -414,4 +414,19 @@ public abstract class ReflectUtil {
     return null;
   }
 
+  /**
+   * Get class object through Type.
+   * 通过Type获取类对象
+   * @param type javaType
+   * @return class object
+   * @throws ClassNotFoundException 
+   *    when type is not ParameterizedTypeImpl and the type name can not get class object in jvm.
+   */
+  public static Class<?> typeToClass(Type type) throws ClassNotFoundException {
+    if (type instanceof ParameterizedTypeImpl) {
+      return ((ParameterizedTypeImpl) type).getRawType();
+    }
+    return Class.forName(type.getTypeName());
+  }
+
 }

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ResultSetUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ResultSetUtil.java
@@ -170,10 +170,7 @@ public class ResultSetUtil {
         ValueWrapper srcId = relationship.srcId();
         result.put(src_id_key, getValue(srcId));
 
-        Map<String, ValueWrapper> dbProps = relationship.properties();
-        Map<String, Object> resultProps = new LinkedHashMap<>();
-        result.put(props_name_key, resultProps);
-        dbProps.forEach((k, v) -> resultProps.put(k, getValue(v)));
+        result.put(props_name_key, edgePropsToMap(relationship));
         
         ValueWrapper dstId = relationship.dstId();
         result.put(dst_id_key, getValue(dstId));
@@ -186,6 +183,13 @@ public class ResultSetUtil {
     return relationship;
   }
 
+  public static Map<String, Object> edgePropsToMap(Relationship relationship)
+      throws UnsupportedEncodingException {
+    Map<String, ValueWrapper> dbProps = relationship.properties();
+    Map<String, Object> resultProps = new LinkedHashMap<>();
+    dbProps.forEach((k, v) -> resultProps.put(k, getValue(v)));
+    return resultProps;
+  }
 
   private static Object nodeToMap(Node node) {
     Map<String, Object> result = new LinkedHashMap<>();
@@ -194,19 +198,25 @@ public class ResultSetUtil {
       result.put(v_id_key, getValue(node.getId()));
       List<String> tagNames = node.tagNames();
       result.put(tags_key, tagNames);
-      Map<String, Object> vertexProps = new LinkedHashMap<>();
-      result.put(props_name_key, vertexProps);
-      for (String tagName : tagNames) {
-        Map<String, ValueWrapper> dbProps = node.properties(tagName);
-        Map<String, Object> labelProps = new LinkedHashMap<>();
-        dbProps.forEach((k, v) -> labelProps.put(k, getValue(v)));
-        vertexProps.put(tagName, labelProps);
-      }
+      result.put(props_name_key, nodePropsToMap(node));
     } catch (UnsupportedEncodingException e) {
       throw new ResultHandleException(
           String.format("%s : %s", e.getClass().toString(), e.getMessage()));
     }
     return result;
+  }
+  
+  public static Map<String, Object> nodePropsToMap(Node node) 
+      throws UnsupportedEncodingException {
+    Map<String, Object> vertexProps = new LinkedHashMap<>();
+    List<String> tagNames = node.tagNames();
+    for (String tagName : tagNames) {
+      Map<String, ValueWrapper> dbProps = node.properties(tagName);
+      Map<String, Object> labelProps = new LinkedHashMap<>();
+      dbProps.forEach((k, v) -> labelProps.put(k, getValue(v)));
+      vertexProps.put(tagName, labelProps);
+    }
+    return vertexProps;
   }
 
   private static Object transformList(ArrayList<ValueWrapper> list) {

--- a/src/main/resources/NebulaDaoBasic.xml
+++ b/src/main/resources/NebulaDaoBasic.xml
@@ -339,6 +339,12 @@
         RETURN n
         LIMIT 1
     </select>
+    
+    <select id="shortestPath" resultType="org.nebula.contrib.ngbatis.models.data.NgPath">
+        @var srcId = ng.valueFmt( srcId );
+        @var dstId = ng.valueFmt( dstId );
+        FIND SHORTEST PATH FROM ${ srcId } TO ${ dstId } OVER * YIELD path AS p
+    </select>
     <!--endregion-->
 
 </mapper>


### PR DESCRIPTION
- feat: provide default data structure for edge \ vertex \ path \ sub-graph, and their result handler. #103 #118
  for example: 
  ```java
  List<NgSubgraph<String>> selectSubgraph();
  ```
  ```xml
  <select id="selectSubgraph" resultType="org.nebula.contrib.ngbatis.models.data.NgSubgraph">
      GET SUBGRAPH WITH PROP 3 STEPS FROM "startVid"
      BOTH like
      YIELD VERTICES AS nodes, EDGES AS relationships
  </select>
  ```
  > ##  **alias must be nodes and relationship.**

- feat: NebulaDaoBasic shortest path support. #118

    ```java
    List<NgPath<String>> ngPaths = dao.shortestPath("startId", "endId");
    ```