### PR TITLE
fix: #120 and new feat: multi tags support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ This source code is licensed under Apache 2.0 License.
 -->
 
 # 1.1.2-SNAPSHOT
+## Develop behavior change.
+- If an entity type is another entity type's super class, all attribute are being required in database schema except `@Transient`
+    > 如果一个实体类是另一个实体类的父类，则其所有除了注解`@Transient` 了的属性，都需要在数据库中声明。
+
+## Bugfix
+- fix: when vertex has multi tags cannot set value properly.[#120](https://github.com/nebula-contrib/ngbatis/issues/120) 
 - fix: `ng.join` bug [#122](https://github.com/nebula-contrib/ngbatis/issues/122)
+## Features
+- feat: multi tags support for vertex inserting.
 - feat: provide default data structure for edge \ vertex \ path \ sub-graph, and their result handler. #103 #118
 - feat: NebulaDaoBasic shortest path support. #118
 - feat: ng.valueFmt support escape ( default true ). Use `ValueFmtFn.setEscape( false );` to disable this feature.

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/pojo/Employee.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/pojo/Employee.java
@@ -1,0 +1,28 @@
+package ye.weicheng.ngbatis.demo.pojo;
+
+// Copyright (c) 2022- All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import javax.persistence.Table;
+
+/**
+ * @author yeweicheng
+ * @since 2023-01-12 13:20
+ *   <br> Now is history!
+ */
+@Table(name = "employee")
+public class Employee extends Person {
+  public Employee() {
+  }
+
+  private String position;
+
+  public String getPosition() {
+    return position;
+  }
+
+  public void setPosition(String position) {
+    this.position = position;
+  }
+}

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/EmployeeDao.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/EmployeeDao.java
@@ -1,0 +1,16 @@
+package ye.weicheng.ngbatis.demo.repository;
+
+// Copyright (c) 2022- All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import org.nebula.contrib.ngbatis.proxy.NebulaDaoBasic;
+import ye.weicheng.ngbatis.demo.pojo.Employee;
+
+/**
+ * @author yeweicheng
+ * @since 2023-01-12 13:16
+ *   <br> Now is history!
+ */
+public interface EmployeeDao extends NebulaDaoBasic<Employee, String> {
+}

--- a/ngbatis-demo/src/main/resources/mapper/EmployeeDao.xml
+++ b/ngbatis-demo/src/main/resources/mapper/EmployeeDao.xml
@@ -1,0 +1,8 @@
+<!--
+    Copyright (c) 2022- All project authors. All rights reserved.
+    
+    This source code is licensed under Apache 2.0 License.
+-->
+<mapper namespace="ye.weicheng.ngbatis.demo.repository.EmployeeDao">
+    
+</mapper>

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/EmployeeDaoTest.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/EmployeeDaoTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import ye.weicheng.ngbatis.demo.pojo.Employee;
 
 /**
+ * Multi tags tests.
  * @author yeweicheng
  * @since 2023-01-12 14:04
  *   <br> Now is history!
@@ -41,7 +42,7 @@ class EmployeeDaoTest {
   @Test
   @Order(1)
   public void insert_multiTag() {
-    Assert.isTrue(dao.selectByIds(ids).size() ==0);;
+    Assert.isTrue(dao.selectByIds(ids).size() == 0);
     Employee employee = new Employee();
     employee.setName("TestMultiTag");
     employee.setPosition("Leader");

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/EmployeeDaoTest.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/EmployeeDaoTest.java
@@ -1,0 +1,89 @@
+package ye.weicheng.ngbatis.demo.repository;
+
+// Copyright (c) 2022- All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import com.alibaba.fastjson.JSON;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.locationtech.jts.util.Assert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import ye.weicheng.ngbatis.demo.pojo.Employee;
+
+/**
+ * @author yeweicheng
+ * @since 2023-01-12 14:04
+ *   <br> Now is history!
+ */
+@SpringBootTest
+@TestMethodOrder(OrderAnnotation.class)
+class EmployeeDaoTest {
+  
+  @Autowired private EmployeeDao dao;
+  @Autowired private TestRepository personDao;
+
+  static List<String> ids = Arrays.asList(
+      "TestMultiTag",
+      "insertSelectiveMT",
+      "TestMultiTagBatch0",
+      "TestMultiTagBatch1",
+      "TestMultiTagBatch2"
+  );
+  
+  @Test
+  @Order(1)
+  public void insert_multiTag() {
+    Assert.isTrue(dao.selectByIds(ids).size() ==0);;
+    Employee employee = new Employee();
+    employee.setName("TestMultiTag");
+    employee.setPosition("Leader");
+    employee.setAge(25);
+    dao.insert(employee);
+  }
+
+  @Test
+  @Order(2)
+  public void insertSelective_multiTags() {
+    Employee employee = new Employee();
+    employee.setName("insertSelectiveMT");
+    employee.setPosition("Leader");
+    employee.setAge(25);
+    dao.insertSelective(employee);
+  }
+
+  @Test
+  @Order(3)
+  public void insertBatch_multiTags() {
+    List<Employee> employees = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      Employee employee = new Employee();
+      employee.setName("TestMultiTagBatch" + i);
+      employee.setPosition("Leader");
+      employee.setAge(25 + i);
+      employee.setBirthday(new Date());
+      employees.add(employee);
+    }
+    dao.insertBatch(employees);
+  }
+  
+  @Test
+  @Order(4)
+  public void selectByIds() {
+    List<Employee> multiTagVertexes = dao.selectByIds(ids);
+    System.out.println(JSON.toJSONString(multiTagVertexes));
+  }
+  
+  @Test
+  @Order(5)
+  public void deleteById() {
+    ids.forEach(dao::deleteById);
+  }
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/KvFn.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/KvFn.java
@@ -6,9 +6,11 @@ package org.nebula.contrib.ngbatis.binding.beetl.functions;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.nebula.contrib.ngbatis.utils.ReflectUtil.getAllColumnFields;
+import static org.nebula.contrib.ngbatis.utils.ReflectUtil.schemaByEntityType;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -94,6 +96,13 @@ public class KvFn extends AbstractFunction<Object, String, Boolean, Boolean, Boo
         name = ReflectUtil.getNameByColumn(field);
       }
       if (name != null) {
+        
+        Class<?> entityType = field.getDeclaringClass();
+        String tagName = schemaByEntityType(entityType);
+        List<String> currentTagColumns = kv.multiTagColumns
+            .computeIfAbsent(tagName, (k) -> new ArrayList<>());
+        currentTagColumns.add(name);
+        
         kv.columns.add(name);
         Object[] paras = {value};
         kv.values.add(fnCall(valueFmtFn, paras));
@@ -106,6 +115,7 @@ public class KvFn extends AbstractFunction<Object, String, Boolean, Boolean, Boo
   }
 
   public static class KV {
+    public final Map<String, List<String>> multiTagColumns = new LinkedHashMap<>();
     public final List<String> columns = new ArrayList<>();
     public final List<String> valueNames = new ArrayList<>();
     public final List<Object> values = new ArrayList<>();

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/TagNameFn.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/TagNameFn.java
@@ -5,10 +5,9 @@ package org.nebula.contrib.ngbatis.binding.beetl.functions;
 // This source code is licensed under Apache 2.0 License.
 
 import static org.nebula.contrib.ngbatis.proxy.NebulaDaoBasicExt.entityType;
+import static org.nebula.contrib.ngbatis.utils.ReflectUtil.schemaByEntityType;
 
-import javax.persistence.Table;
 import org.nebula.contrib.ngbatis.models.ClassModel;
-import org.nebula.contrib.ngbatis.utils.StringUtil;
 
 /**
  * 通过实体对象，获取 vertexName 与 edgeName
@@ -27,9 +26,6 @@ public class TagNameFn extends AbstractFunction<Object, ClassModel, Void, Void, 
     } else {
       entityType = para.getClass();
     }
-    Table tableAnno = entityType.getAnnotation(Table.class);
-    return tableAnno != null
-      ? tableAnno.name()
-      : StringUtil.camelToUnderline(entityType.getSimpleName());
+    return schemaByEntityType(entityType);
   }
 }

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
@@ -12,11 +12,13 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.Id;
+import javax.persistence.Table;
 import javax.persistence.Transient;
 import org.nebula.contrib.ngbatis.exception.ParseException;
 import org.nebula.contrib.ngbatis.models.MethodModel;
@@ -67,7 +69,7 @@ public abstract class ReflectUtil {
 
   public static void setValue(Object o, String prop, Object value)
       throws NoSuchFieldException, IllegalAccessException {
-    Field[] allColumnFields = getAllColumnFields(o.getClass());
+    Field[] allColumnFields = getAllColumnFields(o.getClass(), true);
     Field declaredField = null;
     for (Field columnField : allColumnFields) {
       if (getNameByColumn(columnField).equals(prop)) {
@@ -313,31 +315,25 @@ public abstract class ReflectUtil {
     return parents;
   }
 
+  public static Field[] getAllColumnFields(Class<?> clazz) {
+    return getAllColumnFields(clazz, false);
+  }
+
   /**
    * 实体类获取全部属性，对父类获取 带 @Column 的属性
    *
    * @param clazz 实体类
    * @return 当前类的属性及其父类中，带@Column注解的属性
    */
-  public static Field[] getAllColumnFields(Class<?> clazz) {
-    Set<Field> fields = new HashSet<>();
-    boolean leaf = true;
+  public static Field[] getAllColumnFields(Class<?> clazz, boolean forValueSetting) {
+    Set<Field> fields = new LinkedHashSet<>();
     do {
       Field[] declaredFields = clazz.getDeclaredFields();
-      if (leaf) {
-        Set<Field> cols = Arrays.stream(declaredFields)
-          .filter(el -> !el.isAnnotationPresent(Transient.class))
+      Set<Field> cols = Arrays.stream(declaredFields)
+          .filter(el -> !el.isAnnotationPresent(Transient.class) || forValueSetting)
           .collect(Collectors.toSet());
-        fields.addAll(cols);
-      } else {
-        for (Field declaredField : declaredFields) {
-          if (declaredField.isAnnotationPresent(Column.class)) {
-            fields.add(declaredField);
-          }
-        }
-      }
+      fields.addAll(cols);
       clazz = clazz.getSuperclass();
-      leaf = false;
     } while (clazz != null);
     return fields.toArray(new Field[0]);
   }
@@ -427,6 +423,13 @@ public abstract class ReflectUtil {
       return ((ParameterizedTypeImpl) type).getRawType();
     }
     return Class.forName(type.getTypeName());
+  }
+  
+  public static String schemaByEntityType(Class<?> entityType) {
+    Table tableAnno = entityType.getAnnotation(Table.class);
+    return tableAnno != null
+        ? tableAnno.name()
+        : StringUtil.camelToUnderline(entityType.getSimpleName());
   }
 
 }

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
@@ -315,6 +315,12 @@ public abstract class ReflectUtil {
     return parents;
   }
 
+  /**
+   * 实体类获取全部属性，对父类获取 带 @Column 的属性
+   *
+   * @param clazz 实体类
+   * @return 当前类的属性及其父类中，带@Column注解的属性
+   */
   public static Field[] getAllColumnFields(Class<?> clazz) {
     return getAllColumnFields(clazz, false);
   }
@@ -323,6 +329,7 @@ public abstract class ReflectUtil {
    * 实体类获取全部属性，对父类获取 带 @Column 的属性
    *
    * @param clazz 实体类
+   * @param forValueSetting 用于设值时为 true，读取全属性
    * @return 当前类的属性及其父类中，带@Column注解的属性
    */
   public static Field[] getAllColumnFields(Class<?> clazz, boolean forValueSetting) {
@@ -424,7 +431,12 @@ public abstract class ReflectUtil {
     }
     return Class.forName(type.getTypeName());
   }
-  
+
+  /**
+   * 通过实体类获取 tagName 、edgeName
+   * @param entityType POJO 类型
+   * @return tagName | edgeName
+   */
   public static String schemaByEntityType(Class<?> entityType) {
     Table tableAnno = entityType.getAnnotation(Table.class);
     return tableAnno != null

--- a/src/main/resources/NebulaDaoBasic.xml
+++ b/src/main/resources/NebulaDaoBasic.xml
@@ -152,10 +152,12 @@
     <insert id="insert">
         @var kv = ng.kv( ng_args[0] );
         @var id = ng.id( ng_args[0] );
-        @var tagName = ng.tagName( ng_args[0] );
-        INSERT VERTEX IF NOT EXISTS `${ tagName }` (
-            ${ ng.join( @kv.columns, ", ", "ng.schemaFmt" ) }
-        )
+        INSERT VERTEX IF NOT EXISTS 
+        @for ( entry in @kv.multiTagColumns ) {
+            `${ entry.key }` (
+                ${ ng.join( entry.value, ", ", "ng.schemaFmt" ) }
+            ) ${ entryLP.last ? '' : ','}
+        @}
         VALUES ${ id } : (
             ${ ng.join( @kv.values ) }
         );
@@ -164,10 +166,12 @@
     <insert id="insertSelective">
         @var kv = ng.kv( ng_args[0], '', true, true );
         @var id = ng.id( ng_args[0] );
-        @var tagName = ng.tagName( ng_args[0] );
-        INSERT VERTEX IF NOT EXISTS `${ tagName }` (
-            ${ ng.join( @kv.columns, ", ", "ng.schemaFmt" ) }
-        )
+        INSERT VERTEX IF NOT EXISTS
+        @for ( entry in @kv.multiTagColumns ) {
+            `${ entry.key }` (
+                ${ ng.join( entry.value, ", ", "ng.schemaFmt" ) }
+            ) ${ entryLP.last ? '' : ','}
+        @}
         VALUES ${ id } : (
             ${ ng.join( @kv.values ) }
         );
@@ -177,11 +181,13 @@
         @for ( row in ng_args[0] ) {
             @var kv = ng.kv( row );
             @var id = ng.id( row );
-            @var tagName = ng.tagName( row );
             @if (rowLP.first) {
-            INSERT VERTEX IF NOT EXISTS `${ tagName }` (
-                ${ ng.join( @kv.columns, ", ", "ng.schemaFmt" ) }
-            )
+            INSERT VERTEX IF NOT EXISTS
+            @for ( entry in @kv.multiTagColumns ) {
+                `${ entry.key }` (
+                    ${ ng.join( entry.value, ", ", "ng.schemaFmt" ) }
+                ) ${ entryLP.last ? '' : ','}
+            @}
             VALUES 
             @}
             ${ id } : ( ${ ng.join( @kv.values ) } ) ${ rowLP.last ? '' : ', ' }


### PR DESCRIPTION
- fix: when vertex has multi tags cannot set value properly.[#120](https://github.com/nebula-contrib/ngbatis/issues/120) 
- If an entity type is another entity type's super class, all attribute are being required in database schema except `@Transient`
    > 如果一个实体类是另一个实体类的父类，则其所有除了注解`@Transient` 了的属性，都需要在数据库中声明。
    - `NebulaDaoBasic#insert`、`NebulaDaoBasic#insertSelective`、`NebulaDaoBasic#insertBatch` can create an multi tags vertex, when the param has super class. Such as [Employee.java](/nebula-contrib/ngbatis/blob/master/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/pojo/Employee.java)


cc: @LiuTianyou
What we talk about the column forward marking in #39 has been changed.
In this version, super type entity didn't need forward marking anymore. 
```diff
- When the field in super class we use forward marking to include; @javax.persistence.Column
+ When the field in super class, all the attributes are including except `@javax.persistence.Transient` attributes.
And the field in schema entity we use reverse marking to skip: `@javax.persistence.Transient`
```