### PR TITLE
fix: sessionPool is null when the space name only declared in yml

### DIFF
--- a/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
@@ -193,8 +193,9 @@ class NgbatisBeanFactoryPostProcessor implements BeanFactoryPostProcessor, Order
       return;
     }
 
+    context.getSpaceNameSet().add(nebulaJdbcProperties.getSpace());
     Map<String, SessionPool> nebulaSessionPoolMap = context.getNebulaSessionPoolMap();
-    for (String spaceName : MapperContext.newInstance().getSpaceNameSet()) {
+    for (String spaceName : context.getSpaceNameSet()) {
       SessionPool sessionPool = initSessionPool(spaceName);
       if (sessionPool == null) {
         log.error("{} session pool init failed.", spaceName);


### PR DESCRIPTION
Description: 

We enabled `sessionPool` in the previous version through `nebula.ngbatis.use-session-pool: true`

but when developers set the configuration `nebula.space` in yml only instead of in xml, 

the session pool was not initialized during the startup process.