### PR TITLE
fix: #102 and clear time type mapping (v1.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,29 @@ This source code is licensed under Apache 2.0 License.
     - [ ] index
 - [ ] ResultSetUtil more column types support
   - [ ] Geography
-  - [ ] Duration
+  - [x] Duration
 
 ## Dependencies upgrade
 - [ ] Springboot 3.x support.
+
+# 1.1.4
+## Develop behavior change.
+- When a field is declared by java.util.Date, it is no longer allowed to set a value using Timestamp
+  > 当字段由java.util.Date声明时，不再允许使用java.sql.Timestamp设值
+
+## Bugfix
+- fix: data error for date type in the database.[#102](https://github.com/nebula-contrib/ngbatis/issues/102)
+
+## Feature
+- Clear time type mapping.
+
+  db type | java type
+  ---|---
+  datetime | java.util.Date
+  date | java.sql.Date
+  time | java.sql.Time
+  timestamp | java.sql.Timestamp
+  duration | java.time.Duration
 
 # 1.1.3
 ## Bugfix

--- a/README-CN.md
+++ b/README-CN.md
@@ -34,12 +34,12 @@ This source code is licensed under Apache 2.0 License.
         <dependency>
           <groupId>org.nebula-contrib</groupId>
           <artifactId>ngbatis</artifactId>
-          <version>1.1.3</version>
+          <version>1.1.4</version>
         </dependency>
     ```
   - Gradle
     ```groovy
-    implementation 'org.nebula-contrib:ngbatis:1.1.3'
+    implementation 'org.nebula-contrib:ngbatis:1.1.4'
     ```
 ### 参考 [【ngbatis-demo】](./ngbatis-demo)，与springboot无缝集成。在该项目的 test 中还有api的样例。在开发过程中每增加一个特性也都会同步更新ngbatis-demo的用例。
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ See [EXECUTION-PROCESS.md](./EXECUTION-PROCESS.md)
         <dependency>
           <groupId>org.nebula-contrib</groupId>
           <artifactId>ngbatis</artifactId>
-          <version>1.1.3</version>
+          <version>1.1.4</version>
         </dependency>
     ```
   - Gradle
     ```groovy
-    implementation 'org.nebula-contrib:ngbatis:1.1.3'
+    implementation 'org.nebula-contrib:ngbatis:1.1.4'
     ```
 
 - Referring to [ngbatis-demo](./ngbatis-demo), which was smoothly integrated with spring-boot. The API examples could be found under the test of it for all features of ngbatis.

--- a/ngbatis-demo/pom.xml
+++ b/ngbatis-demo/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.nebula-contrib</groupId>
 			<artifactId>ngbatis</artifactId>
-			<version>1.1.3</version>
+			<version>1.1.4</version>
 		</dependency>
 	</dependencies>
 

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/pojo/TimeTest.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/pojo/TimeTest.java
@@ -1,0 +1,87 @@
+package ye.weicheng.ngbatis.demo.pojo;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.util.Date;
+import javax.persistence.Column;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * @author yeweicheng
+ * @since 2023-06-07 15:26
+ * <br>Now is history!
+ */
+@Table(name = "time_test")
+public class TimeTest {
+  @Id
+  private String id;
+  
+  @Column(name = "t_date")
+  private java.sql.Date date;
+  
+  @Column(name = "t_datetime")
+  private Date datetime;
+  
+  @Column(name = "t_time")
+  private java.sql.Time time;
+  
+  @Column(name = "t_timestamp")
+  private java.sql.Timestamp timestamp;
+
+  @Column(name = "t_duration")
+  private Duration duration;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public java.sql.Date getDate() {
+    return date;
+  }
+
+  public void setDate(java.sql.Date date) {
+    this.date = date;
+  }
+
+  public Date getDatetime() {
+    return datetime;
+  }
+
+  public void setDatetime(Date datetime) {
+    this.datetime = datetime;
+  }
+
+  public Time getTime() {
+    return time;
+  }
+
+  public void setTime(Time time) {
+    this.time = time;
+  }
+
+  public Timestamp getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Timestamp timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public Duration getDuration() {
+    return duration;
+  }
+
+  public void setDuration(Duration duration) {
+    this.duration = duration;
+  }
+}

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/TimeTestDao.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/TimeTestDao.java
@@ -1,0 +1,18 @@
+package ye.weicheng.ngbatis.demo.repository;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.time.Duration;
+import org.nebula.contrib.ngbatis.proxy.NebulaDaoBasic;
+import ye.weicheng.ngbatis.demo.pojo.TimeTest;
+
+/**
+ * @author yeweicheng
+ * @since 2023-06-07 17:17
+ * <br>Now is history!
+ */
+public interface TimeTestDao extends NebulaDaoBasic<TimeTest, String> {
+  Duration selectTenDaysTwoSec();
+}

--- a/ngbatis-demo/src/main/resources/mapper/TimeTestDao.xml
+++ b/ngbatis-demo/src/main/resources/mapper/TimeTestDao.xml
@@ -1,0 +1,12 @@
+<!--
+    Copyright (c) 2022 All project authors. All rights reserved.
+    
+    This source code is licensed under Apache 2.0 License.
+-->
+<mapper namespace="ye.weicheng.ngbatis.demo.repository.TimeTestDao">
+    
+    <select id="selectTenDaysTwoSec">
+        RETURN duration({years: 0, months: 0, days: 10, hours: 0, minutes: 0, seconds: 2})
+    </select>
+    
+</mapper>

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NebulaBasicDaoTests.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NebulaBasicDaoTests.java
@@ -6,7 +6,6 @@ package ye.weicheng.ngbatis.demo;
 
 import com.alibaba.fastjson.JSON;
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -152,7 +151,7 @@ public class NebulaBasicDaoTests {
     Person person = new Person();
     person.setAge(null);
     person.setName("赵小洋");
-    person.setBirthday(new Timestamp(System.currentTimeMillis()));
+    person.setBirthday(new Date());
     repository.insert(person);
   }
 

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NgbatisDemoApplicationTests.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NgbatisDemoApplicationTests.java
@@ -6,8 +6,8 @@ package ye.weicheng.ngbatis.demo;
 
 import com.alibaba.fastjson.JSON;
 import com.vesoft.nebula.client.graph.data.ResultSet;
-import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -243,7 +243,7 @@ class NgbatisDemoApplicationTests {
     Person person = new Person();
     person.setAge(null);
     person.setName("赵小洋");
-    person.setBirthday(new Timestamp(System.currentTimeMillis()));
+    person.setBirthday(new Date());
     repository.insertWithTimestamp(person);
   }
 

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/TimeTestDaoTest.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/TimeTestDaoTest.java
@@ -1,0 +1,99 @@
+package ye.weicheng.ngbatis.demo.repository;
+
+// Copyright (c) 2022 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Objects;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.Assert;
+import ye.weicheng.ngbatis.demo.pojo.TimeTest;
+
+/**
+ * @author yeweicheng
+ * @since 2023-06-07 17:19
+ * <br>Now is history!
+ */
+@SpringBootTest
+@TestMethodOrder(OrderAnnotation.class)
+class TimeTestDaoTest {
+  
+  static final String caseId = "time-test"; 
+  
+  static final Date datetime = new Date();
+  
+  static final java.sql.Date date = new java.sql.Date(datetime.getTime());
+  
+  static final java.sql.Timestamp timestamp = new java.sql.Timestamp(datetime.getTime());
+  
+  static final java.sql.Time time = new java.sql.Time(datetime.getTime());
+  
+  @Autowired private TimeTestDao dao;
+
+  @Test
+  @Order(1)
+  public void testInsert() {
+    TimeTest test = new TimeTest();
+    test.setId(caseId);
+    test.setDatetime(datetime);
+    test.setDate(date);
+    test.setTime(time);
+    test.setTimestamp(timestamp);
+    test.setDuration(java.time.Duration.ofMillis(2000));
+    dao.insert(test);
+  }
+  
+  @Test
+  @Order(2)
+  public void selectById() {
+    TimeTest timeTest = dao.selectById(caseId);
+    Assert.isTrue(
+      Objects.equals(timeTest.getDate().toString(), date.toString()),
+      "Date must be equal to the value before insertion"
+    );
+    
+    Assert.isTrue(
+      Objects.equals(timeTest.getTime().toString(), time.toString()),
+      "Time must be equal to the value before insertion"
+    );
+    
+    Assert.isTrue(
+      Objects.equals(timeTest.getDatetime().toString(), datetime.toString()),
+      "Datetime must be equal to the value before insertion"
+    );
+    
+    String dbTimestamp = String.valueOf(timeTest.getTimestamp().getTime());
+    // 毫秒精度丢失
+    String timestampInsertBefore = (timestamp.getTime() / 1000) + "000";
+    Assert.isTrue(
+      Objects.equals(dbTimestamp, timestampInsertBefore),
+      "Timestamp must be equal to the value before insertion"
+    );
+    
+    Assert.isTrue(
+      timeTest.getDuration().getSeconds() == 2, 
+      "2000ms must be equal 2s"
+    );
+  }
+  
+  @Test
+  @Order(3)
+  public void deleteById() {
+    dao.deleteById(caseId);
+  }
+  
+  @Test
+  @Order(4)
+  public void selectTenDaysTwoSec() {
+    Duration o = dao.selectTenDaysTwoSec();
+    Assert.isTrue(o.getSeconds() == 864002, "10d 2s equals 864002s");
+  }
+  
+}

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>ngbatis</name>
     <groupId>org.nebula-contrib</groupId>
     <artifactId>ngbatis</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
 
     <developers>
         <developer>

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/DefaultArgsResolver.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/DefaultArgsResolver.java
@@ -94,6 +94,14 @@ public class DefaultArgsResolver implements ArgsResolver {
       put(DataSet.class, (Setter<DataSet>) Value::gVal);
       put(Geography.class, (Setter<Geography>) Value::ggVal);
       put(Duration.class, (Setter<Duration>) Value::duVal);
+      put(
+        java.time.Duration.class, 
+        (java.time.Duration du) -> Value.duVal(
+          new Duration()
+            .setSeconds(du.getSeconds())
+            .setMicroseconds(du.getNano() * 1000)
+        )
+      );
     }};
 
   @SuppressWarnings("rawtypes")

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
@@ -80,8 +80,12 @@ public abstract class ReflectUtil {
     if (declaredField == null) {
       throw new NoSuchFieldException(prop);
     }
-    //Field declaredField = o.getClass().getDeclaredField(prop);
-    setValue(o, declaredField, value);
+    if (declaredField.getType() == java.sql.Timestamp.class && value instanceof Long) {
+      setValue(o, declaredField, new java.sql.Timestamp((Long)value * 1000));
+    } else {
+      //Field declaredField = o.getClass().getDeclaredField(prop);
+      setValue(o, declaredField, value);
+    }
   }
 
   /**


### PR DESCRIPTION
# 1.1.4
## Develop behavior change.
- When a field is declared by java.util.Date, it is no longer allowed to set a value using Timestamp
  > 当字段由java.util.Date声明时，不再允许使用java.sql.Timestamp设值

## Bugfix
- fix: data error for date type in the database.[#102](https://github.com/nebula-contrib/ngbatis/issues/102)

## Feature
- Clear time type mapping.

  db type | java type
  ---|---
  datetime | java.util.Date
  date | java.sql.Date
  time | java.sql.Time
  timestamp | java.sql.Timestamp
  duration | java.time.Duration