### PR TITLE
fix: #176 use double quote instead of the original single quote in valuaFmt function

### DIFF
--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NebulaBasicDaoTests.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NebulaBasicDaoTests.java
@@ -142,7 +142,7 @@ public class NebulaBasicDaoTests {
   public void insert() {
     Person person = new Person();
     person.setAge(null);
-    person.setName("赵小洋");
+    person.setName("赵小洋' \" @$");
     repository.insert(person);
   }
 

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/IfStringLike.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/IfStringLike.java
@@ -35,7 +35,7 @@ public class IfStringLike extends AbstractFunction<Object, Class<?>, String, Voi
   public String call(Object value) {
     if (value != null) {
       if (value instanceof String) {
-        return "=~ " + fnCall(valueFmtFn, value);
+        return "=~ " + fnCall(valueFmtFn, value, true);
       } else {
         return "==" + value;
       }

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/IfStringLike.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/IfStringLike.java
@@ -35,7 +35,7 @@ public class IfStringLike extends AbstractFunction<Object, Class<?>, String, Voi
   public String call(Object value) {
     if (value != null) {
       if (value instanceof String) {
-        return "=~ '.*" + value + ".*'";
+        return "=~ " + fnCall(valueFmtFn, value);
       } else {
         return "==" + value;
       }

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/ValueFmtFn.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/ValueFmtFn.java
@@ -21,9 +21,15 @@ import org.apache.commons.text.StringEscapeUtils;
 public class ValueFmtFn extends AbstractFunction<Object, Boolean, Boolean, Void, Void, Void> {
 
   private static boolean escape = true;
+
+  private static String parameterQuote = "\"";
   
   public static void setEscape(boolean escape) {
     ValueFmtFn.escape = escape;
+  }
+  
+  public static void setParameterQuote(String parameterQuote) {
+    ValueFmtFn.parameterQuote = parameterQuote;
   }
 
   @Override
@@ -34,9 +40,10 @@ public class ValueFmtFn extends AbstractFunction<Object, Boolean, Boolean, Void,
       return null;
     }
     if (value instanceof String) {
+      value = (escape ? StringEscapeUtils.escapeJava((String) value) : value);
       return ifStringLike 
-        ? "'.*" + value + ".*'"
-        : "'" + (escape ? StringEscapeUtils.escapeJava((String) value) : value) + "'";
+        ? String.format("%s.*%s.*%s", parameterQuote, value, parameterQuote)
+        : String.format("%s%s%s", parameterQuote, value, parameterQuote);
     }
     
     if (value instanceof BigDecimal) {


### PR DESCRIPTION
## Description
Single quote are not within the scope of StringEscapeUtils.escapeJava escape, 
and double quote are enabled as delimiters for string parameters to avoid the above issues. 

If you still want to use the original single quote due to special processing in the project, 
you can use `ValueFmtFn.setParameterQuote ("'");` to preserve the original usage.

---
单引号不在 StringEscapeUtils.escapeJava 转义的范围内，
启用双引号来作为字符串参数的界定符，从而规避上述问题。

如果项目中因为特殊的处理依然想用原来的单引号，
可用 ValueFmtFn.setParameterQuote("'"); 来保留原用法。


## PR type
- [x] bug fix.