### PR TITLE
fix:#181 when node has multi tag, can not update by subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ This source code is licensed under Apache 2.0 License.
 ## Dependencies upgrade
 - [ ] Springboot 3.x support.
 
+## Bugfix
+- fix: [#176](https://github.com/nebula-contrib/ngbatis/issues/176) use double quote instead of the original single quote in valuaFmt function
+- fix: [#181](https://github.com/nebula-contrib/ngbatis/issues/181) when node has multi tag, can not update by subclass
+  - updateById
+  - updateByIdSelective
+  - updateByIdBatchSelective
+  - updateByIdBatchSelective
+  - upsertByIdSelective
+
 # 1.1.4
 ## Develop behavior change.
 - When a field is declared by java.util.Date, it is no longer allowed to set a value using Timestamp

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/EmployeeDaoTest.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/EmployeeDaoTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Random;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,68 @@ class EmployeeDaoTest {
   
   @Test
   @Order(5)
+  public void updateById_multiTags() {
+    Integer rd = new Random().nextInt();
+    String position = "Leader" + rd;
+    Employee employee = new Employee();
+    employee.setName("TestMultiTag");
+    employee.setPosition(position);
+    employee.setAge(rd);
+    employee.setBirthday(new Date());
+    dao.updateById(employee);
+  }
+
+  @Test
+  @Order(6)
+  public void upsertByIdSelective_multiTags() {
+    Integer rd = new Random().nextInt();
+    String position = "Leader" + rd;
+    Employee employee = new Employee();
+    employee.setName("TestMultiTag");
+    employee.setPosition(position);
+    employee.setAge(rd);
+    employee.setBirthday(new Date());
+    dao.upsertByIdSelective(employee);
+  }
+
+  @Test
+  @Order(7)
+  public void updateByIdSelective_multiTags() {
+    Integer rd = new Random().nextInt();
+    String position = "Leader" + rd;
+    Employee employee = new Employee();
+    employee.setName("insertSelectiveMT");
+    employee.setPosition(position);
+    employee.setAge(rd);
+    employee.setBirthday(new Date());
+    dao.updateByIdSelective(employee);
+  }
+
+  @Test
+  @Order(8)
+  public void updateByIdBatchSelective_multiTags() {
+    List<Employee> employees = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      Integer rd = new Random().nextInt();
+      Employee employee = new Employee();
+      employee.setName("TestMultiTagBatch" + i);
+      employee.setPosition("Leader" + rd);
+      employee.setAge(25 + i);
+      employee.setBirthday(new Date());
+      employees.add(employee);
+    }
+    dao.updateByIdBatchSelective(employees);
+  }
+
+  @Test
+  @Order(9)
+  public void selectByIdsForUpdate() {
+    List<Employee> multiTagVertexes = dao.selectByIds(ids);
+    System.out.println(JSON.toJSONString(multiTagVertexes));
+  }
+
+  @Test
+  @Order(99)
   public void deleteById() {
     ids.forEach(dao::deleteById);
   }

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
@@ -228,14 +228,15 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
     methodModel.setReturnType(entityType);
     methodModel.setResultType(entityType);
     ClassModel classModel = getClassModel(this.getClass());
-    return (T) MapperProxy.invoke(classModel, methodModel, record);
+    MapperProxy.invoke(classModel, methodModel, record);
+    return record;
   }
 
   /**
    * <p>更新</p>
    *
    * @param record 节点
-   * @return 是否删除成功，成功 1，失败 0
+   * @return 原参数对象
    */
   default T updateByIdSelective(T record) {
     MethodModel methodModel = getMethodModel();
@@ -243,7 +244,8 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
     methodModel.setReturnType(entityType);
     methodModel.setResultType(entityType);
     ClassModel classModel = getClassModel(this.getClass());
-    return (T) MapperProxy.invoke(classModel, methodModel, record);
+    MapperProxy.invoke(classModel, methodModel, record);
+    return record;
   }
 
   /**

--- a/src/main/resources/NebulaDaoBasic.xml
+++ b/src/main/resources/NebulaDaoBasic.xml
@@ -202,15 +202,16 @@
         @var pkName = ng.pkName( ng_args[0] );
         @var tagName = ng.tagName( ng_args[0] );
         @var fields = ng.fieldNames( ng_args[0] );
-        UPDATE  VERTEX ON `${ tagName }` ${ id }
-        @if ( isNotEmpty( @kv.columns ) ) {
+        @for ( entry in @kv.multiTagColumns ) {
+            UPDATE  VERTEX ON `${ entry.key }` ${ id }
             SET
-            @for ( col in @kv.columns ) {
-                @var val = @kv.values.get(colLP.dataIndex);
-                `${ col }` = ${ nvl(@val, 'null') } ${ colLP.last ? '' : ',' }
-            @}
+                @for (col in entry.value ) {
+                    @var vIdx = @kv.columns.indexOf( col );
+                    @var val = @kv.values.get(@vIdx);
+                    `${ col }` = ${ nvl(val, "null") } ${ colLP.last ? '' : ','}
+                @}
+            ;
         @}
-        YIELD ${ id } as `${ pkName }`, ${ ng.join( fields, ',', 'ng.schemaFmt' ) }
     </update>
 
     <update id="updateByIdSelective">
@@ -219,15 +220,16 @@
         @var pkName = ng.pkName( ng_args[0] );
         @var tagName = ng.tagName( ng_args[0] );
         @var fields = ng.fieldNames( ng_args[0] );
-        UPDATE  VERTEX ON `${ tagName }` ${ id }
-        @if ( isNotEmpty( @kv.columns ) ) {
+        @for ( entry in @kv.multiTagColumns ) {
+            UPDATE  VERTEX ON `${ entry.key }` ${ id }
             SET
-            @for ( col in @kv.columns ) {
-                @var val = @kv.values.get(colLP.dataIndex);
-                `${ col }` = ${ val } ${ colLP.last ? '' : ',' }
+            @for (col in entry.value ) {
+                @var vIdx = @kv.columns.indexOf( col );
+                @var val = @kv.values.get(@vIdx);
+                `${ col }` = ${ nvl(val, "null") } ${ colLP.last ? '' : ','}
             @}
+            ;
         @}
-        YIELD ${ id } as `${ pkName }`, ${ ng.join( fields, ',', 'ng.schemaFmt' ) }
     </update>
 
     <update id="updateByIdBatchSelective">
@@ -236,15 +238,17 @@
             @var id = ng.id( row );
             @var pkName = ng.pkName( row );
             @var tagName = ng.tagName( row );
-            UPDATE  VERTEX ON `${ tagName }` ${ id }
-                @if ( isNotEmpty( @kv.columns ) ) {
-            SET
-            @for ( col in @kv.columns ) {
-                @var val = @kv.values.get(colLP.dataIndex);
-                    `${ col }` = ${ val } ${ colLP.last ? '' : ',' }
+
+            @for ( entry in @kv.multiTagColumns ) {
+                UPDATE  VERTEX ON `${ entry.key }` ${ id }
+                SET
+                @for (col in entry.value ) {
+                    @var vIdx = @kv.columns.indexOf( col );
+                    @var val = @kv.values.get(@vIdx);
+                    `${ col }` = ${ nvl(val, "null") } ${ colLP.last ? '' : ','}
                 @}
+                ;
             @}
-            ;
         @}
     </update>
 
@@ -255,13 +259,15 @@
         @var tagName = ng.tagName( ng_args[0] );
         @var fields = ng.fieldNames( ng_args[0] );
 
-        UPSERT VERTEX ON `${ tagName }` ${ id }
-        @if ( isNotEmpty( @kv.columns ) ) {
-        SET
-        @for ( col in @kv.columns ) {
-        @var val = @kv.values.get(colLP.dataIndex);
-        `${ col }` = ${ val } ${ colLP.last ? '' : ',' }
-        @}
+        @for ( entry in @kv.multiTagColumns ) {
+            UPSERT  VERTEX ON `${ entry.key }` ${ id }
+            SET
+            @for (col in entry.value ) {
+                @var vIdx = @kv.columns.indexOf( col );
+                @var val = @kv.values.get(@vIdx);
+                `${ col }` = ${ nvl(val, "null") } ${ colLP.last ? '' : ','}
+            @}
+            ;
         @}
     </update>
     <!--endregion-->


### PR DESCRIPTION
fix: when node has multi tag, can not update by subclass.
Here are the methods involved: 
--- 
修复当节点具有多标签（实体类存在继承关系），通过子类无法完成数据更新的问题，
涉及到的方法如下：
  - updateById
  - updateByIdSelective
  - updateByIdBatchSelective
  - updateByIdBatchSelective
  - upsertByIdSelective

PR type
- [x] Bugfix