### PR TITLE
fix #185: improve the accuracy of datetime to milliseconds (v1.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This source code is licensed under Apache 2.0 License.
 ## Dependencies upgrade
 - [ ] Springboot 3.x support.
 
+# 1.1.5
 ## Bugfix
 - fix: [#176](https://github.com/nebula-contrib/ngbatis/issues/176) use double quote instead of the original single quote in valuaFmt function
 - fix: [#181](https://github.com/nebula-contrib/ngbatis/issues/181) when node has multi tag, can not update by subclass
@@ -31,6 +32,7 @@ This source code is licensed under Apache 2.0 License.
   - updateByIdBatchSelective
   - updateByIdBatchSelective
   - upsertByIdSelective
+- fix: [#185](https://github.com/nebula-contrib/ngbatis/issues/185) improve the accuracy of datetime to milliseconds
 
 # 1.1.4
 ## Develop behavior change.

--- a/README-CN.md
+++ b/README-CN.md
@@ -34,12 +34,12 @@ This source code is licensed under Apache 2.0 License.
         <dependency>
           <groupId>org.nebula-contrib</groupId>
           <artifactId>ngbatis</artifactId>
-          <version>1.1.4</version>
+          <version>1.1.5</version>
         </dependency>
     ```
   - Gradle
     ```groovy
-    implementation 'org.nebula-contrib:ngbatis:1.1.4'
+    implementation 'org.nebula-contrib:ngbatis:1.1.5'
     ```
 ### 参考 [【ngbatis-demo】](./ngbatis-demo)，与springboot无缝集成。在该项目的 test 中还有api的样例。在开发过程中每增加一个特性也都会同步更新ngbatis-demo的用例。
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ See [EXECUTION-PROCESS.md](./EXECUTION-PROCESS.md)
         <dependency>
           <groupId>org.nebula-contrib</groupId>
           <artifactId>ngbatis</artifactId>
-          <version>1.1.4</version>
+          <version>1.1.5</version>
         </dependency>
     ```
   - Gradle
     ```groovy
-    implementation 'org.nebula-contrib:ngbatis:1.1.4'
+    implementation 'org.nebula-contrib:ngbatis:1.1.5'
     ```
 
 - Referring to [ngbatis-demo](./ngbatis-demo), which was smoothly integrated with spring-boot. The API examples could be found under the test of it for all features of ngbatis.

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/TimeTestDaoTest.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/TimeTestDaoTest.java
@@ -65,7 +65,7 @@ class TimeTestDaoTest {
     );
     
     Assert.isTrue(
-      Objects.equals(timeTest.getDatetime().toString(), datetime.toString()),
+      Objects.equals(timeTest.getDatetime().getTime(), datetime.getTime()),
       "Datetime must be equal to the value before insertion"
     );
     

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>ngbatis</name>
     <groupId>org.nebula-contrib</groupId>
     <artifactId>ngbatis</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.1.5</version>
 
     <developers>
         <developer>

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/DateDeserializer.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/DateDeserializer.java
@@ -12,6 +12,7 @@ import java.text.SimpleDateFormat;
  * @since 2022-08-29 8:06
  *     Now is history!
  */
+@Deprecated
 public class DateDeserializer implements ObjectSerializer {
 
   @Override

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/ValueFmtFn.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/ValueFmtFn.java
@@ -20,6 +20,10 @@ import org.apache.commons.text.StringEscapeUtils;
  */
 public class ValueFmtFn extends AbstractFunction<Object, Boolean, Boolean, Void, Void, Void> {
 
+  private static final String DATE_FMT = "yyyy-MM-dd";
+  private static final String TIME_FMT = "HH:mm:ss.SSS";
+  private static final String DATETIME_FMT = String.format("%s'T'%s", DATE_FMT, TIME_FMT);
+  
   private static boolean escape = true;
 
   private static String parameterQuote = "\"";
@@ -64,10 +68,10 @@ public class ValueFmtFn extends AbstractFunction<Object, Boolean, Boolean, Void,
         return String.format("%s(%d)", "timestamp", (((Timestamp) value).getTime() / 1000));
       }
 
-      String timePattern = objClass == java.util.Date.class ? "yyyy-MM-dd'T'HH:mm:ss.sss"
-        : objClass == java.sql.Date.class ? "yyyy-MM-dd"
-          : objClass == java.sql.Time.class ? "HH:mm:ss.sss"
-            : "yyyy-MM-dd'T'HH:mm:ss.sss";
+      String timePattern = objClass == java.util.Date.class ? DATETIME_FMT
+        : objClass == java.sql.Date.class ? DATE_FMT
+          : objClass == java.sql.Time.class ? TIME_FMT
+            : DATETIME_FMT;
       SimpleDateFormat sdf = new SimpleDateFormat(timePattern);
       
       String fn = "datetime";

--- a/src/test/java/org/nebula/contrib/ngbatis/binding/DateDeserializerTest.java
+++ b/src/test/java/org/nebula/contrib/ngbatis/binding/DateDeserializerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
  * @since 2022-06-22 4:44
  * <br>Now is history!
  */
+@Deprecated
 class DateDeserializerTest {
 
   @Test


### PR DESCRIPTION
- Change the time format from `yyyy-MM-dd'T'HH:mm:ss.sss` to `yyyy-MM-dd'T'HH:mm:ss.SSS`
- When converting `Date`, read microsec from `DateTimeWrapper` and change to millisec

PR type
- [x] Bugfix