### PR TITLE
fix: when DAO/Mapper method has `Page` type param with `@Param`, the param name can not be use. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ This source code is licensed under Apache 2.0 License.
 - fix: [#194](https://github.com/nebula-contrib/ngbatis/issues/194) we can name the interface by `@Component` and `@Resource`, for example:
   - `@Component("namedMapper")`: use `@Resource("namedMapper$Proxy")` to inject. (since v1.0)
   - `@Resource("namedComponent")`: use `@Resource("namedComponent")` to inject. (new feature)
+- fix: when DAO/Mapper method has `Page` type param with `@Param`, the param name can not be use. 
+  > 如原来项目中分页相关接口，用了不起作用的 `@Param`, 但 xml 还是使用 p0, p1... 
+  > 需要将 `@Param` 移除，或者将 xml 中的参数名改成 注解的参数名，以保证参数名统一
 
 ## Develop behavior change.
 - Remove deprecated classes and methods:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ This source code is licensed under Apache 2.0 License.
 - [ ] Springboot 3.x support.
 
 # NEXT
+## Dependencies upgrade
+- nebula-java: 3.5.0 -> 3.6.0
+
 ## Bugfix
 - fix: [#190](https://github.com/nebula-contrib/ngbatis/issues/190) Insert failed when tag has no attributes
 - chore: removing and exclude some packages: log4j related or useless.

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>com.vesoft</groupId>
             <artifactId>client</artifactId>
-            <version>3.5.0</version>
+            <version>3.6.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/nebula/contrib/ngbatis/models/MethodModel.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/MethodModel.java
@@ -56,6 +56,11 @@ public class MethodModel {
    */
   private Class<?>[] parameterTypes;
 
+  /**
+   * {@link #method} 参数列表的参数注解
+   */
+  private Annotation[][] paramAnnotations;
+
   // ---------------- info in interface start ---------------------
   /**
    * 用于 asm 的方法签名。
@@ -127,6 +132,14 @@ public class MethodModel {
     this.parameterTypes = parameterTypes;
   }
 
+  public Annotation[][] getParamAnnotations() {
+    return paramAnnotations;
+  }
+
+  public void setParamAnnotations(Annotation[][] paramAnnotations) {
+    this.paramAnnotations = paramAnnotations;
+  }
+
   public int getParameterCount() {
     return method == null ? parameterTypes.length : method.getParameterCount();
   }
@@ -146,6 +159,8 @@ public class MethodModel {
   public Annotation[][] getParameterAnnotations() {
     if (method != null) {
       return method.getParameterAnnotations();
+    } else if (paramAnnotations != null) {
+      return paramAnnotations;
     }
     return new Annotation[getParameterCount()][];
   }


### PR DESCRIPTION

## Dependencies upgrade
- nebula-java: 3.5.0 -> 3.6.0

- fix: when DAO/Mapper method has `Page` type param with `@Param`, the param name can not be use. 
  > 如原来项目中分页相关接口，用了不起作用的 `@Param`, 但 xml 还是使用 p0, p1... 
  > 需要将 `@Param` 移除，或者将 xml 中的参数名改成 注解的参数名，以保证参数名统一

PR type:
- [x] Bugfix