### PR TITLE
ci: skip javadoc in maven publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,4 @@ jobs:
           gpg_passphrase: ${{ secrets.GPG_PASSWORD }}
           nexus_username: ${{ secrets.OSSRH_USER }}
           nexus_password: ${{ secrets.OSSRH_PASSWORD }}
+          maven-goals: 'deploy -Dmaven.javadoc.skip=true'

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -39,3 +39,4 @@ jobs:
           gpg_passphrase: ${{ secrets.GPG_PASSWORD }}
           nexus_username: ${{ secrets.OSSRH_USER }}
           nexus_password: ${{ secrets.OSSRH_PASSWORD }}
+          maven-goals: 'deploy -Dmaven.javadoc.skip=true'


### PR DESCRIPTION
I don't know why recent mvn CI failed due to javadoc failures, it's strange that it was not triggered before though.

Let's explicitly skip it.