### PR TITLE
ci drop old gh action, use mvn directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Install Java and Maven
+      - name: Setup Java
         uses: actions/setup-java@v3
         with:
           java-version: '8'
@@ -30,11 +30,17 @@ jobs:
           popd
           popd
 
-      - name: Release Maven package
-        uses: samuelmeuli/action-maven-publish@v1
+      - name: Set up Apache Maven Central
+        uses: actions/setup-java@v3
         with:
-          gpg_private_key: ${{ secrets.GPG_SECRET }}
-          gpg_passphrase: ${{ secrets.GPG_PASSWORD }}
-          nexus_username: ${{ secrets.OSSRH_USER }}
-          nexus_password: ${{ secrets.OSSRH_PASSWORD }}
-          maven_args: '-Dmaven.javadoc.skip=true'
+          java-version: '8'
+          distribution: 'temurin'
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: ${{ secrets.GPG_PASSWORD }}
+
+      - name: Publish package
+        run: mvn --batch-mode deploy -Dmaven.javadoc.skip=true
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USER }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - name: Install Java and Maven
+      - name: Setup Java
         uses: actions/setup-java@v3
         with:
           java-version: '8'
@@ -32,11 +32,17 @@ jobs:
           popd
           popd
 
-      - name: Deploy Snapshot to Maven package
-        uses: samuelmeuli/action-maven-publish@v1
+      - name: Set up Apache Maven Central
+        uses: actions/setup-java@v3
         with:
-          gpg_private_key: ${{ secrets.GPG_SECRET }}
-          gpg_passphrase: ${{ secrets.GPG_PASSWORD }}
-          nexus_username: ${{ secrets.OSSRH_USER }}
-          nexus_password: ${{ secrets.OSSRH_PASSWORD }}
-          maven_args: '-Dmaven.javadoc.skip=true'
+          java-version: '8'
+          distribution: 'temurin'
+          gpg-private-key: ${{ secrets.GPG_SECRET }}
+          gpg-passphrase: ${{ secrets.GPG_PASSWORD }}
+
+      - name: Publish package
+        run: mvn --batch-mode deploy -Dmaven.javadoc.skip=true
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USER }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSWORD }}


### PR DESCRIPTION
ref: 

- https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md
- https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven

close: #223

Let's see how this works now, We don't need the archived action [here](https://github.com/samuelmeuli/action-maven-publish) now