### PR TITLE
fix: ci not setting up pages in doc dryrun

### DIFF
--- a/.github/workflows/doc_en_pull_request_dryrun.yaml
+++ b/.github/workflows/doc_en_pull_request_dryrun.yaml
@@ -2,8 +2,8 @@
 name: Dry run Docs Build in PR
 
 on:
-
   pull_request:
+    types: [opened, synchronize, reopened]
     branches: [master]
     paths:
       - 'docs/**'
@@ -48,10 +48,8 @@ jobs:
           node-version: 18
           cache: npm
           cache-dependency-path: ngbatis-docs/package-lock.json
-          
-      - name: Setup Pages
-        uses: actions/configure-pages@v3
-      - name: Build with VitePress
+
+      - name: Dryrun Build with VitePress
         run: |
           cd ngbatis-docs
           npm ci


### PR DESCRIPTION
## issue

I just realized the dryrun action will wipe the github page, sorry for this.

I just had to manually rerun the vitepress job to bring the en docs back.

## changes

- dryrun only happened in pr before merge
- removed the wrong step, this will wipe the pages

ref:

1. opened: A new pull request is created.
2. synchronize: The pull request's branch is updated with new commits.
3. reopened: A closed pull request is reopened.