### PR TITLE
ci: remove file scope of vitepress

### DIFF
--- a/.github/workflows/doc_en.yaml
+++ b/.github/workflows/doc_en.yaml
@@ -5,9 +5,6 @@ on:
 
   push:
     branches: [master]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
it seems github page wiping will still be triggered even after we have the ignore dot file, now let's force Vitepress being built for all merged PR to protect the github page