### PR TITLE
v1.2.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,20 @@ This source code is licensed under Apache 2.0 License.
 
 - [ ] Springboot 3.x support.
 
-# NEXT
+# 1.2.0-beta
 
 ## Dependencies upgrade
 
 - nebula-java: 3.5.0 -> 3.6.0
 - beetl: 3.1.8-RELEASE -> 3.15.10.RELEASE
 - antlr4: 4.7.2 -> 4.11.1
+
+## Feature
+
+- feat: support `<nGQL>` include query pieces. ([#212](https://github.com/nebula-contrib/ngbatis/pull/212), via [dieyi](https://github.com/1244453393))
+- feat: extending `NgPath`, when 'with prop' is used in nGQL, edge attributes can be obtained from NgPath. ([#212](https://github.com/nebula-contrib/ngbatis/pull/212), via [dieyi](https://github.com/1244453393))
+- feat: expanding the `insertEdgeBatch` interface in `NebulaDaoBasic`. ([#244](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))
+- feat: expanding the `deleteByIdBatch` interface in `NebulaDaoBasic`. ([#247](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))
 
 ## Bugfix
 
@@ -55,6 +62,7 @@ This source code is licensed under Apache 2.0 License.
 - fix: when DAO/Mapper method has `Page` type param with `@Param`, the param name can not be use.
   > 如原来项目中分页相关接口，用了不起作用的 `@Param`, 但 xml 还是使用 p0, p1...
   > 需要将 `@Param` 移除，或者将 xml 中的参数名改成 注解的参数名，以保证参数名统一
+- fix:class 'ResultSetUtil.java' parse datetime type error. ([#241](https://github.com/nebula-contrib/ngbatis/pull/241), via [爱吃辣条的Jerry](https://github.com/bobobod))
 
 ## Develop behavior change
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ This source code is licensed under Apache 2.0 License.
 ## Feature
 
 - feat: support `<nGQL>` include query pieces. ([#212](https://github.com/nebula-contrib/ngbatis/pull/212), via [dieyi](https://github.com/1244453393))
-- feat: extending `NgPath`, when 'with prop' is used in nGQL, edge attributes can be obtained from NgPath. ([#212](https://github.com/nebula-contrib/ngbatis/pull/212), via [dieyi](https://github.com/1244453393))
+- feat: extending `NgPath`, when 'with prop' is used in nGQL, edge attributes can be obtained from NgPath. ([#228](https://github.com/nebula-contrib/ngbatis/pull/228), via [dieyi](https://github.com/1244453393))
 - feat: expanding the `insertEdgeBatch` interface in `NebulaDaoBasic`. ([#244](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))
 - feat: expanding the `deleteByIdBatch` interface in `NebulaDaoBasic`. ([#247](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This source code is licensed under Apache 2.0 License.
 - [ ] Expand the function of NebulaDaoBasic
   - [ ] Add batch interface:
     - [ ] insertTripletBatch
-    - [ ] insertEdgeBatch
+    - [x] insertEdgeBatch
     - [ ] ...
   - [ ] Schema support:
     - [ ] show metas

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This source code is licensed under Apache 2.0 License.
 </p>
 
 - [Ngbatis Docs](https://nebula-contrib.github.io/ngbatis/)
-- [Ngbatis 文档](https://corvusye.github.io/ngbatis-docs/)
+- [Ngbatis 文档](https://graph-cn.github.io/ngbatis-docs/)
 
 ## What is NGBATIS
 

--- a/ngbatis-demo/pom.xml
+++ b/ngbatis-demo/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.nebula-contrib</groupId>
 			<artifactId>ngbatis</artifactId>
-			<version>1.2.0-SNAPSHOT</version>
+			<version>1.2.0-beta</version>
 		</dependency>
 	</dependencies>
 

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/DropSpaceDao.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/DropSpaceDao.java
@@ -14,9 +14,11 @@ import java.util.List;
  */
 public interface DropSpaceDao {
   
-  void createSpace(String name);
+  void useTestSpace();
   
-  void dropSpace(String name);
+  void createSpace();
+  
+  void dropSpace();
   
   List<String> showTags();
   

--- a/ngbatis-demo/src/main/resources/mapper/DropSpaceDao.xml
+++ b/ngbatis-demo/src/main/resources/mapper/DropSpaceDao.xml
@@ -6,11 +6,15 @@
 <mapper namespace="ye.weicheng.ngbatis.demo.repository.DropSpaceDao" space="test_drop">
   
   <delete id="dropSpace">
-    drop space ${ p0 };
+    drop space test_drop;
   </delete>
   
+  <select id="useTestSpace" space="test">
+    RETURN 1;
+  </select>
+  
   <select id="createSpace" space="null">
-    create space ${ p0 } ( vid_type  = INT64 );
+    create space test_drop ( vid_type  = INT64 );
   </select>
   
   <select id="showTags" resultType="java.lang.String">

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/DropSpaceDaoTest.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/DropSpaceDaoTest.java
@@ -22,14 +22,14 @@ class DropSpaceDaoTest {
   
   @Test
   void dropSpace() throws InterruptedException {
-    String spaceName = "test_drop";
-    dao.createSpace(spaceName);
+    dao.useTestSpace();
+    dao.createSpace();
     Thread.sleep(10 * 1000);
     
     List<String> tags = dao.showTags();
     System.out.println(tags);
     
-    dao.dropSpace(spaceName);
+    dao.dropSpace();
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>ngbatis</name>
     <groupId>org.nebula-contrib</groupId>
     <artifactId>ngbatis</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0-beta</version>
 
     <developers>
         <developer>

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
@@ -319,7 +319,7 @@ public class MapperProxy {
     gql = gql.trim();
     String sessionSpace = localSession.getCurrentSpace();
     boolean sameSpace = Objects.equals(sessionSpace, currentSpace);
-    if (!sameSpace) {
+    if (!sameSpace && currentSpace !=  null) {
       qlAndSpace[0] = currentSpace;
       Session session = localSession.getSession();
       ResultSet execute = session.execute(String.format("USE `%s`", currentSpace));

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
@@ -291,7 +291,7 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
    * @param id 表记录主键
    * @return 是否执行成功，成功 1 ，失败 0
    */
-  default int deleteWithEdgeById(I id) {
+  default Integer deleteWithEdgeById(I id) {
     MethodModel methodModel = getMethodModel();
     methodModel.setReturnType(ResultSet.class);
     methodModel.setResultType(ResultSet.class);
@@ -306,7 +306,7 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
    * @param id 表记录主键
    * @return 是否删除成功，成功 1，失败 0
    */
-  default int deleteById(I id) {
+  default Integer deleteById(I id) {
     MethodModel methodModel = getMethodModel();
     methodModel.setReturnType(ResultSet.class);
     methodModel.setResultType(ResultSet.class);
@@ -322,7 +322,7 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
    * @param ids 表记录主键列表
    * @return 是否删除成功，成功 1，失败 0
    */
-  default int deleteByIdBatch(Collection<I> ids) {
+  default Integer deleteByIdBatch(Collection<I> ids) {
     MethodModel methodModel = getMethodModel();
     methodModel.setReturnType(ResultSet.class);
     methodModel.setResultType(ResultSet.class);


### PR DESCRIPTION
### It's been a while since the last release, and some basic structures have changed. To avoid conflicts, we plan to release a beta version first.


# 1.2.0-beta

## Dependencies upgrade

- nebula-java: 3.5.0 -> 3.6.0
- beetl: 3.1.8-RELEASE -> 3.15.10.RELEASE
- antlr4: 4.7.2 -> 4.11.1

## Feature

- feat: support `<nGQL>` include query pieces. ([#212](https://github.com/nebula-contrib/ngbatis/pull/212), via [dieyi](https://github.com/1244453393))
- feat: extending `NgPath`, when 'with prop' is used in nGQL, edge attributes can be obtained from NgPath. ([#228](https://github.com/nebula-contrib/ngbatis/pull/228), via [dieyi](https://github.com/1244453393))
- feat: expanding the `insertEdgeBatch` interface in `NebulaDaoBasic`. ([#244](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))
- feat: expanding the `deleteByIdBatch` interface in `NebulaDaoBasic`. ([#247](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))

## Bugfix

- fix: support methods in mapper tags to set space to null.
  - Such as:

  ```xml
  <mapper namespace="...">
    <create id="createSpace" space="null">
      create space new_space ( vid_type  = INT64 );
    </create>
  </mapper>
  ```

- fix: [#190](https://github.com/nebula-contrib/ngbatis/issues/190) Insert failed when tag has no attributes
- chore: removing and exclude some packages: log4j related or useless.
- fix: [#194](https://github.com/nebula-contrib/ngbatis/issues/194) we can name the interface by `@Component` and `@Resource`, for example:
  - `@Component("namedMapper")`: use `@Resource("namedMapper$Proxy")` to inject. (since v1.0)
  - `@Resource("namedComponent")`: use `@Resource("namedComponent")` to inject. (new feature)
- fix: when DAO/Mapper method has `Page` type param with `@Param`, the param name can not be use.
  > 如原来项目中分页相关接口，用了不起作用的 `@Param`, 但 xml 还是使用 p0, p1...
  > 需要将 `@Param` 移除，或者将 xml 中的参数名改成 注解的参数名，以保证参数名统一
- fix: class 'ResultSetUtil.java' parse datetime type error. ([#241](https://github.com/nebula-contrib/ngbatis/pull/241), via [爱吃辣条的Jerry](https://github.com/bobobod))

## Develop behavior change

- Remove deprecated classes and methods:
  - org.nebula.contrib.ngbatis.binding.DateDeserializer
  - org.nebula.contrib.ngbatis.binding.DefaultArgsResolver#customToJson
- Dependencies changing:
  > 如果项目中有用到，且出现相关类找不到的情况，请自行引入
  - Exclude:

    ```xml
    <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter</artifactId>
        <exclusions>
            <exclusion>
                <groupId>org.apache.logging.log4j</groupId>
                <artifactId>log4j-to-slf4j</artifactId>
            </exclusion>
            <exclusion>
                <groupId>org.apache.logging.log4j</groupId>
                <artifactId>log4j-api</artifactId>
            </exclusion>
            <exclusion>
                <groupId>org.springframework.boot</groupId>
                <artifactId>spring-boot-starter-web</artifactId>
            </exclusion>
        </exclusions>
    </dependency>
    ```
  
  - Removing:

    ```xml
    <!-- Why: make it possible to use undertow as web server -->
    <dependency> 
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-web</artifactId>
    </dependency>
    <!-- Why: useless in NgBatis-->
    <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-jdbc</artifactId>
    </dependency>
    <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-aop</artifactId>
    </dependency>
    ```
