### PR TITLE
v1.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           server-password: MAVEN_PASSWORD  # Environment variable for Maven password
 
       - name: Publish package
-        run: mvn --batch-mode deploy
+        run: mvn --batch-mode deploy -Dmaven.javadoc.skip=true
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USER }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This source code is licensed under Apache 2.0 License.
 
 - [ ] Springboot 3.x support.
 
-# 1.2.0-beta
+# 1.2.0
 
 ## Dependencies upgrade
 

--- a/README-CN.md
+++ b/README-CN.md
@@ -39,14 +39,14 @@ This source code is licensed under Apache 2.0 License.
         <dependency>
           <groupId>org.nebula-contrib</groupId>
           <artifactId>ngbatis</artifactId>
-          <version>1.1.5</version>
+          <version>1.2.0</version>
         </dependency>
     ```
 
 - Gradle
 
     ```groovy
-    implementation 'org.nebula-contrib:ngbatis:1.1.5'
+    implementation 'org.nebula-contrib:ngbatis:1.2.0'
     ```
 
 ### 参考 [【ngbatis-demo】](./ngbatis-demo)，与springboot无缝集成。在该项目的 test 中还有api的样例。在开发过程中每增加一个特性也都会同步更新ngbatis-demo的用例
@@ -107,6 +107,9 @@ import java.util.Map;
 import java.util.Set;
 
 public interface TestRepository {
+    // new features from v1.2.0
+    Integer returnAge(@Param("person")Person person);
+  
     Person selectPerson();
     Person selectByPerson(Person person);
     List<Person> selectAgeGt(Integer age);
@@ -126,6 +129,24 @@ resource/mapper/TestRepository.xml
     namespace=
     "ye.weicheng.ngbatis.demo.repository.TestRepository"
 >
+    <!-- v1.2.0 新特性 start -->
+    <nGQL id="include-test-value">
+        ${myInt}
+    </nGQL>
+
+    <nGQL id="ngql-return-age">
+        RETURN @ng.include('include-test-value',{'myInt':age});
+    </nGQL>
+
+    <!--
+    等同于: 
+        RETURN ${person.age};
+    你可以试着提取更多有意义的公共脚本.
+    -->
+    <select id="returnAge" resultType="java.lang.Integer">
+        @ng.include('ngql-return-age',person);
+    </select>
+    <!-- v1.2.0 新特性 v1.2.0 end -->
 
     <select id="selectPerson" resultType="ye.weicheng.ngbatis.demo.pojo.Person">
         match (v:person) return v.person.name as name, v.person.age as age limit 1

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ See [EXECUTION-PROCESS.md](./EXECUTION-PROCESS.md)
         <dependency>
           <groupId>org.nebula-contrib</groupId>
           <artifactId>ngbatis</artifactId>
-          <version>1.1.5</version>
+          <version>1.2.0</version>
         </dependency>
     ```
 
   - Gradle
 
     ```groovy
-    implementation 'org.nebula-contrib:ngbatis:1.1.5'
+    implementation 'org.nebula-contrib:ngbatis:1.2.0'
     ```
 
 - Referring to [ngbatis-demo](./ngbatis-demo), which was smoothly integrated with spring-boot. The API examples could be found under the test of it for all features of ngbatis.
@@ -109,6 +109,9 @@ import java.util.Map;
 import java.util.Set;
 
 public interface TestRepository {
+    // new features from v1.2.0
+    Integer returnAge(@Param("person")Person person);
+
     Person selectPerson();
     Person selectByPerson(Person person);
     List<Person> selectAgeGt(Integer age);
@@ -128,6 +131,24 @@ public interface TestRepository {
     namespace=
     "ye.weicheng.ngbatis.demo.repository.TestRepository"
 >
+    <!-- new features from v1.2.0 start -->
+    <nGQL id="include-test-value">
+        ${myInt}
+    </nGQL>
+
+    <nGQL id="ngql-return-age">
+        RETURN @ng.include('include-test-value',{'myInt':age});
+    </nGQL>
+
+    <!--
+    The same as: 
+        RETURN ${person.age};
+    You can try extracting more common and meaningful scripts.
+    -->
+    <select id="returnAge" resultType="java.lang.Integer">
+        @ng.include('ngql-return-age',person);
+    </select>
+    <!-- new features from v1.2.0 end -->
 
     <select id="selectPerson" resultType="ye.weicheng.ngbatis.demo.pojo.Person">
         match (v:person) return v.person.name as name, v.person.age as age limit 1

--- a/ngbatis-demo/pom.xml
+++ b/ngbatis-demo/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.nebula-contrib</groupId>
 			<artifactId>ngbatis</artifactId>
-			<version>1.2.0-beta</version>
+			<version>1.2.0</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>ngbatis</name>
     <groupId>org.nebula-contrib</groupId>
     <artifactId>ngbatis</artifactId>
-    <version>1.2.0-beta</version>
+    <version>1.2.0</version>
 
     <developers>
         <developer>


### PR DESCRIPTION

# 1.2.0

## Dependencies upgrade

- nebula-java: 3.5.0 -> 3.6.0
- beetl: 3.1.8-RELEASE -> 3.15.10.RELEASE
- antlr4: 4.7.2 -> 4.11.1

## Feature

- feat: support `<nGQL>` include query pieces. ([#212](https://github.com/nebula-contrib/ngbatis/pull/212), via [dieyi](https://github.com/1244453393))
- feat: extending `NgPath`, when 'with prop' is used in nGQL, edge attributes can be obtained from NgPath. ([#228](https://github.com/nebula-contrib/ngbatis/pull/228), via [dieyi](https://github.com/1244453393))
- feat: expanding the `insertEdgeBatch` interface in `NebulaDaoBasic`. ([#244](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))
- feat: expanding the `deleteByIdBatch` interface in `NebulaDaoBasic`. ([#247](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))

## Bugfix

- fix: support methods in mapper tags to set space to null.
  - Such as:

  ```xml
  <mapper namespace="...">
    <create id="createSpace" space="null">
      create space new_space ( vid_type  = INT64 );
    </create>
  </mapper>
  ```

- fix: [#190](https://github.com/nebula-contrib/ngbatis/issues/190) Insert failed when tag has no attributes
- chore: removing and exclude some packages: log4j related or useless.
- fix: [#194](https://github.com/nebula-contrib/ngbatis/issues/194) we can name the interface by `@Component` and `@Resource`, for example:
  - `@Component("namedMapper")`: use `@Resource("namedMapper$Proxy")` to inject. (since v1.0)
  - `@Resource("namedComponent")`: use `@Resource("namedComponent")` to inject. (new feature)
- fix: when DAO/Mapper method has `Page` type param with `@Param`, the param name can not be use.
  > 如原来项目中分页相关接口，用了不起作用的 `@Param`, 但 xml 还是使用 p0, p1...
  > 需要将 `@Param` 移除，或者将 xml 中的参数名改成 注解的参数名，以保证参数名统一
- fix:class 'ResultSetUtil.java' parse datetime type error. ([#241](https://github.com/nebula-contrib/ngbatis/pull/241), via [爱吃辣条的Jerry](https://github.com/bobobod))

## Develop behavior change

- Remove deprecated classes and methods:
  - org.nebula.contrib.ngbatis.binding.DateDeserializer
  - org.nebula.contrib.ngbatis.binding.DefaultArgsResolver#customToJson
- Dependencies changing:
  > 如果项目中有用到，且出现相关类找不到的情况，请自行引入
  - Exclude:

    ```xml
    <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter</artifactId>
        <exclusions>
            <exclusion>
                <groupId>org.apache.logging.log4j</groupId>
                <artifactId>log4j-to-slf4j</artifactId>
            </exclusion>
            <exclusion>
                <groupId>org.apache.logging.log4j</groupId>
                <artifactId>log4j-api</artifactId>
            </exclusion>
            <exclusion>
                <groupId>org.springframework.boot</groupId>
                <artifactId>spring-boot-starter-web</artifactId>
            </exclusion>
        </exclusions>
    </dependency>
    ```
  
  - Removing:

    ```xml
    <!-- Why: make it possible to use undertow as web server -->
    <dependency> 
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-web</artifactId>
    </dependency>
    <!-- Why: useless in NgBatis-->
    <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-jdbc</artifactId>
    </dependency>
    <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-aop</artifactId>
    </dependency>
    ```