### PR TITLE
feat: support specify space by param, fix #265

### DIFF
--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/TestRepository.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/TestRepository.java
@@ -80,6 +80,7 @@ public interface TestRepository extends NebulaDaoBasic<Person, String> {
   
   void insertDynamic(List<DynamicNode> list);
 
+  Boolean spaceFromParam(@Param("specifySpace") String specifySpace);
   
   class DynamicNode {
     @Id

--- a/ngbatis-demo/src/main/resources/mapper/TestRepository.xml
+++ b/ngbatis-demo/src/main/resources/mapper/TestRepository.xml
@@ -154,6 +154,10 @@
         @}
     </insert>
     
+    <select id="spaceFromParam" space="${specifySpace}" spaceFromParam="true">
+        RETURN true;
+    </select>
+    
 
 </mapper>
 

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NgbatisDemoApplicationTests.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/NgbatisDemoApplicationTests.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.util.Assert;
+import org.nebula.contrib.ngbatis.exception.QueryException;
 import org.nebula.contrib.ngbatis.models.data.NgEdge;
 import org.nebula.contrib.ngbatis.models.data.NgSubgraph;
 import org.nebula.contrib.ngbatis.models.data.NgVertex;
@@ -235,6 +236,16 @@ class NgbatisDemoApplicationTests {
           break;
         default: break;
       }
+    }
+  }
+
+  @Test
+  public void spaceFromParam() {
+    String spaceName = "test" + System.currentTimeMillis();
+    try {
+      repository.spaceFromParam(spaceName);
+    } catch (Exception e) {
+      Assert.isTrue(e instanceof QueryException && e.getMessage().contains("SpaceNotFound"));
     }
   }
   

--- a/src/main/java/org/nebula/contrib/ngbatis/config/ParseCfgProps.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/config/ParseCfgProps.java
@@ -32,6 +32,8 @@ public class ParseCfgProps {
   private String namespace = "namespace";
 
   private String space = "space";
+  
+  private String spaceFromParam = "spaceFromParam";
 
   private String resultType = "resultType";
 
@@ -135,6 +137,15 @@ public class ParseCfgProps {
 
   public void setSpace(String space) {
     this.space = space;
+  }
+
+  public String getSpaceFromParam() {
+    return spaceFromParam;
+  }
+
+  public ParseCfgProps setSpaceFromParam(String spaceFromParam) {
+    this.spaceFromParam = spaceFromParam;
+    return this;
   }
 
   public String getResultType() {

--- a/src/main/java/org/nebula/contrib/ngbatis/models/MethodModel.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/MethodModel.java
@@ -47,6 +47,11 @@ public class MethodModel {
   private Class returnType;
 
   /**
+   * 是否从参数中设置空间
+   */
+  private boolean spaceFromParam;
+
+  /**
    * XXXDao 的方法对象
    */
   private Method method;
@@ -150,6 +155,14 @@ public class MethodModel {
 
   public void setReturnType(Class returnType) {
     this.returnType = returnType;
+  }
+
+  public boolean isSpaceFromParam() {
+    return spaceFromParam;
+  }
+
+  public void setSpaceFromParam(boolean spaceFromParam) {
+    this.spaceFromParam = spaceFromParam;
   }
 
   /**

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
@@ -226,7 +226,7 @@ public class MapperProxy {
         localSessionSpace = localSession.getCurrentSpace();
       }
 
-      String currentSpace = getSpace(cm, mm);
+      String currentSpace = getSpace(cm, mm, paramsForTemplate);
       String[] qlAndSpace = qlWithSpace(localSession, gql, currentSpace);
       gql = qlAndSpace[1];
       autoSwitch = qlAndSpace[0] == null ? "" : qlAndSpace[0];
@@ -244,7 +244,7 @@ public class MapperProxy {
       if (log.isDebugEnabled()) {
         log.debug("\n\t- proxyMethod: {}#{}"
                 + "\n\t- session space: {}"
-                + (isEmpty(autoSwitch) ? "{}" : "\n\t- auto switch to: {}")
+                + (isEmpty(autoSwitch) ? "\n\t- {}" : "\n\t- auto switch to: {}")
                 + "\n\t- nGql：{}"
                 + "\n\t- params: {}"
                 + "\n\t- result：{}",
@@ -276,7 +276,7 @@ public class MapperProxy {
         proxyMethod = stackTraceElement.getMethodName();
       }
 
-      currentSpace = getSpace(cm, mm);
+      currentSpace = getSpace(cm, mm, paramsForTemplate);
       SessionPool sessionPool = ENV.getSessionPool(currentSpace);
       if (sessionPool == null) {
         throw new QueryException(currentSpace + " sessionPool is null");
@@ -347,6 +347,20 @@ public class MapperProxy {
       )
       : cm != null && cm.getSpace() != null ? cm.getSpace()
         : ENV.getSpace();
+  }
+
+  /**
+   * 支持space从参数中获取
+   * @param cm 当前接口的类模型
+   * @param mm 当前接口方法的方法模型
+   * @param paramsForTemplate 从模板参数中获取空间名
+   * @return 目标space
+   */
+  public static String getSpace(ClassModel cm, MethodModel mm, Map<String, Object> paramsForTemplate) {
+    boolean spaceFromParam = mm.isSpaceFromParam();
+    String space = getSpace(cm, mm);
+    if (spaceFromParam && space != null) return ENV.getTextResolver().resolve(space, paramsForTemplate);
+    return space;
   }
 
   /**

--- a/src/main/resources/ngbatis-mapper.dtd
+++ b/src/main/resources/ngbatis-mapper.dtd
@@ -11,6 +11,7 @@ space CDATA
 id CDATA #REQUIRED
 parameterType CDATA #IMPLIED
 space CDATA
+spaceFromParam (true|false)
 >
 
 <!ELEMENT update (#PCDATA)*>
@@ -18,6 +19,7 @@ space CDATA
 id CDATA #REQUIRED
 parameterType CDATA #IMPLIED
 space CDATA
+spaceFromParam (true|false)
 >
 
 <!ELEMENT delete (#PCDATA)*>
@@ -25,6 +27,7 @@ space CDATA
 id CDATA #REQUIRED
 parameterType CDATA #IMPLIED
 space CDATA
+spaceFromParam (true|false)
 >
 
 <!ELEMENT select (#PCDATA)*>
@@ -33,6 +36,7 @@ id CDATA #REQUIRED
 parameterType CDATA #IMPLIED
 resultType CDATA #IMPLIED
 space CDATA
+spaceFromParam (true|false)
 >
 
 <!ELEMENT nGQL (#PCDATA)*>


### PR DESCRIPTION
For example:

```java
  Boolean spaceFromParam(@Param("specifySpace") String specifySpace);
```

```xml
    <select id="spaceFromParam" space="${specifySpace}" spaceFromParam="true">
        RETURN true;
    </select>
```

If the `specifySpace` is not current space, NgBatis will automatically switch.
Can reduce the use of `use space` in ngql.

close: #265