### PR TITLE
fix: remove unnecessary reflections in transformDateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This source code is licensed under Apache 2.0 License.
 
 - [ ] Springboot 3.x support.
 
-# 1.2.0
+# 1.2.0-SNAPSHOT
 
 ## Dependencies upgrade
 
@@ -63,6 +63,7 @@ This source code is licensed under Apache 2.0 License.
   > 如原来项目中分页相关接口，用了不起作用的 `@Param`, 但 xml 还是使用 p0, p1...
   > 需要将 `@Param` 移除，或者将 xml 中的参数名改成 注解的参数名，以保证参数名统一
 - fix:class 'ResultSetUtil.java' parse datetime type error. ([#241](https://github.com/nebula-contrib/ngbatis/pull/241), via [爱吃辣条的Jerry](https://github.com/bobobod))
+- fix: remove unnecessary reflections in transformDateTime, and prevents errors in the millisecond bit in jdk17.
 
 ## Develop behavior change
 

--- a/ngbatis-demo/pom.xml
+++ b/ngbatis-demo/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>org.nebula-contrib</groupId>
 			<artifactId>ngbatis</artifactId>
-			<version>1.2.0</version>
+			<version>1.2.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <name>ngbatis</name>
     <groupId>org.nebula-contrib</groupId>
     <artifactId>ngbatis</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <developers>
         <developer>

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ResultSetUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ResultSetUtil.java
@@ -23,6 +23,8 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -68,18 +70,6 @@ public class ResultSetUtil {
   public static String type_vertex_value = "vertex";
   
   public static String type_edge_value = "edge";
-
-  private static final Constructor<GregorianCalendar> CALENDAR_CONSTRUCTOR;
-
-  static {
-    try {
-      CALENDAR_CONSTRUCTOR = GregorianCalendar.class.getDeclaredConstructor(
-        int.class, int.class, int.class, int.class, int.class, int.class, int.class
-      );
-    } catch (NoSuchMethodException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   /**
    * <p>根据nebula graph本身的类型说明，获取对应的 java对象值。</p>
@@ -128,29 +118,20 @@ public class ResultSetUtil {
 
   private static Object transformDateTime(DateTimeWrapper dateTime) {
     DateTime localDateTime = dateTime.getLocalDateTime();
-    try {
-      CALENDAR_CONSTRUCTOR.setAccessible(true);
-      GregorianCalendar calendar = CALENDAR_CONSTRUCTOR.newInstance(
-        localDateTime.getYear(),
-        localDateTime.getMonth() - 1,
-        localDateTime.getDay(),
-        localDateTime.getHour(),
-        localDateTime.getMinute(),
-        localDateTime.getSec(),
-        Math.floorDiv(localDateTime.getMicrosec(), 1000)
-      );
-      CALENDAR_CONSTRUCTOR.setAccessible(false);
-      return calendar.getTime();
-    } catch (Exception e) {
-      return new GregorianCalendar(
-        localDateTime.getYear(),
-        localDateTime.getMonth() - 1,
-        localDateTime.getDay(),
-        localDateTime.getHour(),
-        localDateTime.getMinute(),
-        localDateTime.getSec()
-        ).getTime();
-    }
+
+    int month = localDateTime.getMonth() - 1;
+    GregorianCalendar calendar = new GregorianCalendar(
+      localDateTime.getYear(),
+      month,
+      localDateTime.getDay(),
+      localDateTime.getHour(),
+      localDateTime.getMinute(),
+      localDateTime.getSec()
+    );
+    
+    calendar.set(Calendar.MILLISECOND, Math.floorDiv(localDateTime.getMicrosec(), 1000));
+
+    return calendar.getTime();
   }
 
   private static Object transformDate(DateWrapper date) {


### PR DESCRIPTION
Remove unnecessary reflections in transformDateTime, and prevents errors in the millisecond bit in jdk17.
Make the same code applicable to both jdk8 and jdk17 versions, reducing maintenance costs.