### PR TITLE
feat: support the use of ciphertext passwords in yml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This source code is licensed under Apache 2.0 License.
 
 ## Feature
 
+- feat: support the use of ciphertext passwords in yml.
+- feat: expanding the `insertSelectiveBatch` interface in `NebulaDaoBasic`.
+
 # 1.2.2
 
 ## Bugfix
@@ -73,8 +76,8 @@ This source code is licensed under Apache 2.0 License.
 - feat: support `<nGQL>` include query pieces. ([#212](https://github.com/nebula-contrib/ngbatis/pull/212), via [dieyi](https://github.com/1244453393))
 - feat: extending `NgPath`, when 'with prop' is used in nGQL, edge attributes can be obtained from NgPath. ([#228](https://github.com/nebula-contrib/ngbatis/pull/228), via [dieyi](https://github.com/1244453393))
 - feat: expanding the `insertEdgeBatch` interface in `NebulaDaoBasic`. ([#244](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))
-- feat: expanding the `deleteByIdBatch` interface in `NebulaDaoBasic`. ([#247](https://github.com/nebula-contrib/ngbatis/pull/244), via [Sunhb](https://github.com/shbone))
-- feat: expanding the `listEndNodes` interface in `NebulaDaoBasic`. ([#247](https://github.com/nebula-contrib/ngbatis/pull/272), via [knqiufan](https://github.com/knqiufan))
+- feat: expanding the `deleteByIdBatch` interface in `NebulaDaoBasic`. ([#247](https://github.com/nebula-contrib/ngbatis/pull/247), via [Sunhb](https://github.com/shbone))
+- feat: expanding the `listEndNodes` interface in `NebulaDaoBasic`. ([#272](https://github.com/nebula-contrib/ngbatis/pull/272), via [knqiufan](https://github.com/knqiufan))
 - feat: support specify space by param
 
 ## Bugfix

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/config/Base64PasswordDecoder.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/config/Base64PasswordDecoder.java
@@ -1,0 +1,27 @@
+package ye.weicheng.ngbatis.demo.config;
+
+// Copyright (c) 2024 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.util.Base64;
+import org.nebula.contrib.ngbatis.PasswordDecoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * yml 明码解密器的组建示例，使用 Base64 的方式
+ * 如 yml 使用的是明文密码，则不需要这个 bean
+ * 
+ * @author yeweicheng
+ * @since 2024-05-23 7:39
+ * <br>Now is history!
+ */
+@Component
+public class Base64PasswordDecoder implements PasswordDecoder {
+
+  @Override
+  public String decode(String password) {
+    return new String(Base64.getDecoder().decode(password));
+  }
+
+}

--- a/ngbatis-demo/src/main/resources/application.yml
+++ b/ngbatis-demo/src/main/resources/application.yml
@@ -14,7 +14,7 @@ nebula:
     use-session-pool: false
   hosts: 127.0.0.1:19669
   username: root
-  password: nebula
+  password: bmVidWxh
   space: test
   pool-config:
     min-conns-size: 0

--- a/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
@@ -24,6 +24,7 @@ import org.nebula.contrib.ngbatis.proxy.RamClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -59,8 +60,17 @@ class NgbatisBeanFactoryPostProcessor implements BeanFactoryPostProcessor, Order
   @Override
   public void postProcessBeanFactory(
       ConfigurableListableBeanFactory configurableListableBeanFactory) throws BeansException {
+    setBeans(configurableListableBeanFactory);
     NebulaPool nebulaPool = nebulaPool();
     mapperContext(nebulaPool);
+  }
+
+  private void setBeans(ConfigurableListableBeanFactory beanFactory) {
+    ObjectProvider<PasswordDecoder> passwordDecoders =
+      beanFactory.getBeanProvider(PasswordDecoder.class);
+
+    PasswordDecoder passwordDecoder = passwordDecoders.getIfAvailable();
+    nebulaJdbcProperties.setPasswordDecoder(passwordDecoder);
   }
 
   public MapperContext mapperContext(NebulaPool nebulaPool) {

--- a/src/main/java/org/nebula/contrib/ngbatis/PasswordDecoder.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/PasswordDecoder.java
@@ -1,0 +1,18 @@
+package org.nebula.contrib.ngbatis;
+
+// Copyright (c) 2024 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+/**
+ * 用于：从配置中得到的密码，可以解密获得明文密码
+ * 
+ * @author yeweicheng
+ * @since 2024-05-23 7:31
+ * <br>Now is history!
+ */
+public interface PasswordDecoder {
+  
+  String decode(String password);
+
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/config/NebulaJdbcProperties.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/config/NebulaJdbcProperties.java
@@ -8,6 +8,8 @@ import com.vesoft.nebula.client.graph.NebulaPoolConfig;
 import com.vesoft.nebula.client.graph.data.HostAddress;
 import java.util.ArrayList;
 import java.util.List;
+import org.nebula.contrib.ngbatis.PasswordDecoder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -52,6 +54,9 @@ public class NebulaJdbcProperties {
    * 当前所有的数据库空间
    */
   private String space;
+
+  @Autowired(required = false)
+  private PasswordDecoder passwordDecoder;
 
   public NebulaJdbcProperties() {
   }
@@ -101,7 +106,7 @@ public class NebulaJdbcProperties {
   }
 
   public String getPassword() {
-    return password;
+    return passwordDecoder == null ? password : passwordDecoder.decode(password);
   }
 
   public NebulaJdbcProperties setPassword(String password) {
@@ -127,5 +132,13 @@ public class NebulaJdbcProperties {
     return this;
   }
 
+
+  public PasswordDecoder getPasswordDecoder() {
+    return passwordDecoder;
+  }
+
+  public void setPasswordDecoder(PasswordDecoder passwordDecoder) {
+    this.passwordDecoder = passwordDecoder;
+  }
 }
 

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
@@ -224,7 +224,7 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
    * 批量插入非空字段
    * @param ts 当前Tag下多个顶点
    */
-  default void insertSelectiveBatch(List<? extends T> ts){
+  default void insertSelectiveBatch(List<? extends T> ts) {
     MethodModel methodModel = getMethodModel();
     ClassModel classModel = getClassModel(this.getClass());
     MapperProxy.invoke(classModel,methodModel,ts);


### PR DESCRIPTION
Support for #298 

### Developers can create a custom decoder that implements the interface `PasswordDecoder`

For example:

```java
@Component
public class Base64PasswordDecoder implements PasswordDecoder {

  @Override
  public String decode(String password) {
    return new String(Base64.getDecoder().decode(password));
  }

}
```

```yml
nebula:
  username: root
  password: bmVidWxh # actual password is: nebula
```

## Tip:
At this stage, it is **not** supported to use `@Value` to inject additional attributes.
现阶段 **不** 支持使用 `@Value` 注入额外属性。

PR type:
- [x] new feat