### PR TITLE
2 fix, 2 dependencies changed, 1 feat. refer to the description for more detail.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This source code is licensed under Apache 2.0 License.
 
 ## Bugfix
 
+- fix: when `use-session-pool` and spaceFromParam is true, skip the space addition
+
 ## Feature
 
 - feat: support the use of ciphertext passwords in yml.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ This source code is licensed under Apache 2.0 License.
 
 # NEXT
 
+## Dependencies upgrade
+
+- nebula-java: 3.6.0 -> 3.8.3
+- org.hibernate:hibernate-core was excluded.
+> If you need to use hibernate-core, please add the dependency by yourself.
+
 ## Bugfix
 
 - fix: when `use-session-pool` and spaceFromParam is true, skip the space addition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,15 @@ This source code is licensed under Apache 2.0 License.
 
 ## Bugfix
 
-- fix: when `use-session-pool` and spaceFromParam is true, skip the space addition
+- fix: when `use-session-pool` and spaceFromParam is true, skip the space addition.
+- fix: when timezone is not default, the time is incorrect.
 
 ## Feature
 
 - feat: support the use of ciphertext passwords in yml.
-- feat: expanding the `insertSelectiveBatch` interface in `NebulaDaoBasic`.
+- feat: expanding the `insertSelectiveBatch` interface in `NebulaDaoBasic`.([#299](https://github.com/nebula-contrib/ngbatis/pull/299), via [Ozjq](https://github.com/Ozjq))
+- feat: expanding the `shortestOptionalPath` interface in `NebulaDaoBasic`.([#303](https://github.com/nebula-contrib/ngbatis/pull/303), via [xYLiu](https://github.com/n3A87))
+- feat: expanding the `showSpaces` interface in `NebulaDaoBasic`.([#304](https://github.com/nebula-contrib/ngbatis/pull/304), via [xYLiu](https://github.com/n3A87))
 
 # 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,30 @@ This source code is licensed under Apache 2.0 License.
 - feat: expanding the `insertSelectiveBatch` interface in `NebulaDaoBasic`.([#299](https://github.com/nebula-contrib/ngbatis/pull/299), via [Ozjq](https://github.com/Ozjq))
 - feat: expanding the `shortestOptionalPath` interface in `NebulaDaoBasic`.([#303](https://github.com/nebula-contrib/ngbatis/pull/303), via [xYLiu](https://github.com/n3A87))
 - feat: expanding the `showSpaces` interface in `NebulaDaoBasic`.([#304](https://github.com/nebula-contrib/ngbatis/pull/304), via [xYLiu](https://github.com/n3A87))
+- feat: support ssl and http2 config in yml.
+  > http2 属于企业版的数据库才支持，但我没有测试环境，所以不确定是否可用。
+  > http2 is supported by the enterprise version of the database, but I don't have a test environment, so I'm not sure if it works.
+
+  - example:
+
+    ```yaml
+    nebula:
+      pool-config:
+        enable-ssl: true
+        ssl-param:
+          sign-mode: SELF_SIGNED
+          crt-file-path: /path/to/client.crt
+          key-file-path: /path/to/client.key
+          password: password
+        # ssl-param:
+          # sign-mode: CA_SIGNED
+          # ca-crt-file-path: /path/to/ca-client.crt
+          # crt-file-path: /path/to/client.crt
+          # key-file-path: /path/to/client.key
+        use-http2: false
+        custom-headers:
+          Route-Tag: abc
+    ```
 
 # 1.2.2
 

--- a/ngbatis-demo/src/main/resources/mapper/DropSpaceDao.xml
+++ b/ngbatis-demo/src/main/resources/mapper/DropSpaceDao.xml
@@ -3,7 +3,7 @@
     
     This source code is licensed under Apache 2.0 License.
 -->
-<mapper namespace="ye.weicheng.ngbatis.demo.repository.DropSpaceDao" space="test_drop">
+<mapper namespace="ye.weicheng.ngbatis.demo.repository.DropSpaceDao">
   
   <delete id="dropSpace">
     drop space test_drop;
@@ -13,7 +13,7 @@
     RETURN 1;
   </select>
   
-  <select id="createSpace" space="null">
+  <select id="createSpace" space="null" spaceFromParam="true">
     create space test_drop ( vid_type  = INT64 );
   </select>
   

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.vesoft</groupId>
             <artifactId>client</artifactId>
-            <version>3.6.0</version>
+            <version>3.8.3</version>
         </dependency>
 
         <dependency>
@@ -87,6 +87,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
@@ -233,7 +233,12 @@ class NgbatisBeanFactoryPostProcessor implements BeanFactoryPostProcessor, Order
             spaceName,
             nebulaJdbcProperties.getUsername(),
             nebulaJdbcProperties.getPassword()
-    );
+    ).setUseHttp2(poolConfig.isUseHttp2())
+      .setEnableSsl(poolConfig.isEnableSsl())
+      .setSslParam(poolConfig.getSslParam())
+      .setCustomHeaders(poolConfig.getCustomHeaders())
+      .setWaitTime(poolConfig.getWaitTime())
+      .setTimeout(poolConfig.getTimeout());
 
     if (poolConfig.getMinConnSize() <= 0) {
       sessionPoolConfig.setMinSessionSize(1);
@@ -252,11 +257,7 @@ class NgbatisBeanFactoryPostProcessor implements BeanFactoryPostProcessor, Order
       sessionPoolConfig.setHealthCheckTime(healthCheckTime);
     }
 
-    SessionPool sessionPool = new SessionPool(sessionPoolConfig);
-    if (!sessionPool.init()) {
-      return null;
-    }
-    return sessionPool;
+    return new SessionPool(sessionPoolConfig);
   }
 
   @Override

--- a/src/main/java/org/nebula/contrib/ngbatis/NgbatisContextInitializer.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/NgbatisContextInitializer.java
@@ -14,7 +14,7 @@ import java.util.Map;
 import org.nebula.contrib.ngbatis.config.NebulaJdbcProperties;
 import org.nebula.contrib.ngbatis.config.NgbatisConfig;
 import org.nebula.contrib.ngbatis.config.ParseCfgProps;
-import org.nebula.contrib.ngbatis.models.ext.SettableCASignedSSLParam;
+import org.nebula.contrib.ngbatis.models.ext.SettableCaSignedSslParam;
 import org.nebula.contrib.ngbatis.models.ext.SettableSelfSignedSSLParam;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -133,7 +133,7 @@ public class NgbatisContextInitializer implements ApplicationContextInitializer 
 
       Class<? extends SSLParam> sslParamClass = signMode == SignMode.SELF_SIGNED
         ? SettableSelfSignedSSLParam.class
-        : SettableCASignedSSLParam.class;
+        : SettableCaSignedSslParam.class;
       
       SSLParam sslParam = getConfig(
         environment, 

--- a/src/main/java/org/nebula/contrib/ngbatis/io/MapperResourceLoader.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/io/MapperResourceLoader.java
@@ -175,7 +175,9 @@ public class MapperResourceLoader extends PathMatchingResourcePatternResolver {
           cm.getNgqls().put(ngqlModel.getId(),ngqlModel);
         } else {
           MethodModel methodModel = parseMethodModel(methodNode);
-          addSpaceToSessionPool(methodModel.getSpace());
+          if (!methodModel.isSpaceFromParam()) {
+            addSpaceToSessionPool(methodModel.getSpace());
+          }
           Method method = getNameUniqueMethod(namespace, methodModel.getId());
           methodModel.setMethod(method);
           Assert.notNull(method,

--- a/src/main/java/org/nebula/contrib/ngbatis/models/ext/SettableCASignedSSLParam.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/ext/SettableCASignedSSLParam.java
@@ -1,0 +1,35 @@
+package org.nebula.contrib.ngbatis.models.ext;
+
+// Copyright (c) 2024 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import static org.nebula.contrib.ngbatis.utils.ReflectUtil.setValue;
+
+import com.vesoft.nebula.client.graph.data.CASignedSSLParam;
+
+/**
+ * 属性可设置的 CA 签名 SSL 参数
+ * 
+ * @author yeweicheng
+ * @since 2024-07-05 4:27
+ * <br>Now is history!
+ */
+public class SettableCASignedSSLParam extends CASignedSSLParam {
+
+  public void setCaCrtFilePath(String caCrtFilePath) 
+      throws NoSuchFieldException, IllegalAccessException {
+    setValue(this, "caCrtFilePath", caCrtFilePath);
+  }
+
+  public void setCrtFilePath(String certFilePath)
+      throws NoSuchFieldException, IllegalAccessException {
+    setValue(this, "crtFilePath", certFilePath);
+  }
+
+  public void setKeyFilePath(String keyFilePath)
+      throws NoSuchFieldException, IllegalAccessException {
+    setValue(this, "keyFilePath", keyFilePath);
+  }
+
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/models/ext/SettableCaSignedSslParam.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/ext/SettableCaSignedSslParam.java
@@ -15,7 +15,7 @@ import com.vesoft.nebula.client.graph.data.CASignedSSLParam;
  * @since 2024-07-05 4:27
  * <br>Now is history!
  */
-public class SettableCASignedSSLParam extends CASignedSSLParam {
+public class SettableCaSignedSslParam extends CASignedSSLParam {
 
   public void setCaCrtFilePath(String caCrtFilePath) 
       throws NoSuchFieldException, IllegalAccessException {

--- a/src/main/java/org/nebula/contrib/ngbatis/models/ext/SettableSelfSignedSSLParam.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/ext/SettableSelfSignedSSLParam.java
@@ -1,0 +1,39 @@
+package org.nebula.contrib.ngbatis.models.ext;
+
+// Copyright (c) 2024 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import static org.nebula.contrib.ngbatis.utils.ReflectUtil.setValue;
+
+import com.vesoft.nebula.client.graph.data.SelfSignedSSLParam;
+
+/**
+ * 属性可设置的自签名 SSL 参数
+ * 
+ * @author yeweicheng
+ * @since 2024-07-05 4:35
+ * <br>Now is history!
+ */
+public class SettableSelfSignedSSLParam extends SelfSignedSSLParam {
+
+  public SettableSelfSignedSSLParam() {
+    super(null, null, null);
+  }
+  
+  public void setPassword(String password)
+    throws NoSuchFieldException, IllegalAccessException {
+    setValue(this, "password", password);
+  }
+  
+  public void setCrtFilePath(String crtFilePath)
+    throws NoSuchFieldException, IllegalAccessException {
+    setValue(this, "crtFilePath", crtFilePath);
+  }
+  
+  public void setKeyFilePath(String keyFilePath)
+    throws NoSuchFieldException, IllegalAccessException {
+    setValue(this, "keyFilePath", keyFilePath);
+  }
+  
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/models/ext/SettableSelfSignedSSLParam.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/models/ext/SettableSelfSignedSSLParam.java
@@ -22,17 +22,17 @@ public class SettableSelfSignedSSLParam extends SelfSignedSSLParam {
   }
   
   public void setPassword(String password)
-    throws NoSuchFieldException, IllegalAccessException {
+      throws NoSuchFieldException, IllegalAccessException {
     setValue(this, "password", password);
   }
   
   public void setCrtFilePath(String crtFilePath)
-    throws NoSuchFieldException, IllegalAccessException {
+      throws NoSuchFieldException, IllegalAccessException {
     setValue(this, "crtFilePath", crtFilePath);
   }
   
   public void setKeyFilePath(String keyFilePath)
-    throws NoSuchFieldException, IllegalAccessException {
+      throws NoSuchFieldException, IllegalAccessException {
     setValue(this, "keyFilePath", keyFilePath);
   }
   

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
@@ -13,13 +13,11 @@ import static org.nebula.contrib.ngbatis.proxy.NebulaDaoBasicExt.pkType;
 import static org.nebula.contrib.ngbatis.proxy.NebulaDaoBasicExt.proxy;
 import static org.nebula.contrib.ngbatis.proxy.NebulaDaoBasicExt.vertexName;
 
-import com.sun.istack.internal.NotNull;
 import com.vesoft.nebula.client.graph.data.ResultSet;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.nebula.contrib.ngbatis.exception.QueryException;
@@ -345,13 +343,13 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
 
   // region graph special
   /**
-   * 根据三元组值，插入关系
+   * 根据三元组值，插入关系。任一参数为空，不执行。
    *
    * @param v1 开始节点值 或 开始节点id
    * @param e  关系值
    * @param v2 结束节点值 或 结束节点id
    */
-  default void insertEdge(@NotNull Object v1, @NotNull Object e, @NotNull Object v2) {
+  default void insertEdge(Object v1, Object e, Object v2) {
     if (v2 == null || v1 == null || e == null) {
       return;
     }
@@ -372,14 +370,14 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
   }
 
   /**
-   * 根据三元组值, 插入关系
+   * 根据三元组值, 插入关系。任一参数为空，不执行。
    * <p>Selective: 仅处理非空字段</p>
    *
    * @param src 开始节点值
    * @param edge  关系值
    * @param dst 结束节点值
    */
-  default void insertEdgeSelective(@NotNull Object src, @NotNull Object edge, @NotNull Object dst) {
+  default void insertEdgeSelective(Object src, Object edge, Object dst) {
     if (dst == null || src == null || edge == null) {
       return;
     }
@@ -389,14 +387,14 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
   }
 
   /**
-   * 根据三元组值, 插入关系
+   * 根据三元组值, 插入关系。任一参数为空，不执行。
    * <p>Selective: 仅处理非空字段</p>
    *
    * @param src 开始节点值
    * @param edge  关系值
    * @param dst 结束节点值
    */
-  default void upsertEdgeSelective(@NotNull Object src, @NotNull Object edge, @NotNull Object dst) {
+  default void upsertEdgeSelective(Object src, Object edge, Object dst) {
     if (dst == null || src == null || edge == null) {
       return;
     }

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
@@ -13,7 +13,7 @@ import static org.nebula.contrib.ngbatis.proxy.NebulaDaoBasicExt.pkType;
 import static org.nebula.contrib.ngbatis.proxy.NebulaDaoBasicExt.proxy;
 import static org.nebula.contrib.ngbatis.proxy.NebulaDaoBasicExt.vertexName;
 
-import com.sun.istack.NotNull;
+import com.sun.istack.internal.NotNull;
 import com.vesoft.nebula.client.graph.data.ResultSet;
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ConfigUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ConfigUtil.java
@@ -1,0 +1,53 @@
+package org.nebula.contrib.ngbatis.utils;
+
+// Copyright (c) 2024 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.bind.BindResult;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * 配置的工具类，用于完成配置到对象的转换
+ * 
+ * @author yeweicheng
+ * @since 2024-07-03 13:44
+ * <br>Now is history!
+ */
+public class ConfigUtil {
+
+  public static <T> T getConfig(ConfigurableEnvironment environment, String prefix,
+      Class<T> clazz) {
+    PropertySource<?> configurationProperties = environment.getPropertySources()
+      .get("configurationProperties");
+    if (configurationProperties == null) {
+      return null;
+    }
+    Object sources = configurationProperties.getSource();
+    List<ConfigurationPropertySource> sourceList = new ArrayList<>();
+    if (sources instanceof Iterable) {
+      for (Object source : (Iterable<?>) sources) {
+        if (source instanceof ConfigurationPropertySource) {
+          sourceList.add((ConfigurationPropertySource) source);
+        }
+      }
+
+      Binder binder = new Binder(sourceList);
+      Bindable<T> bindable = Bindable.of(ResolvableType.forClass(clazz));
+      
+      BindResult<T> result = binder.bind(prefix, bindable);
+      if (result.isBound()) {
+        return result.get();
+      }
+    }
+    return null;
+  }
+  
+}

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ResultSetUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ResultSetUtil.java
@@ -11,6 +11,7 @@ import static org.nebula.contrib.ngbatis.utils.ReflectUtil.schemaByEntityType;
 
 import com.vesoft.nebula.DateTime;
 import com.vesoft.nebula.ErrorCode;
+import com.vesoft.nebula.Time;
 import com.vesoft.nebula.client.graph.data.DateTimeWrapper;
 import com.vesoft.nebula.client.graph.data.DateWrapper;
 import com.vesoft.nebula.client.graph.data.DurationWrapper;
@@ -138,7 +139,8 @@ public class ResultSetUtil {
   }
 
   private static Object transformTime(TimeWrapper time) {
-    return new java.sql.Time(time.getHour(), time.getMinute(), time.getSecond());
+    Time localTime = time.getLocalTime();
+    return new java.sql.Time(localTime.getHour(), localTime.getMinute(), localTime.getSec());
   }
 
   private static Object transformDuration(DurationWrapper du) {


### PR DESCRIPTION
## [fix: treat space from param as invalid, when use-session-pool is true.](https://github.com/nebula-contrib/ngbatis/commit/76edb79284ee736f384665821b16ea3414c096ba)


## [fix: when timezone is not default, the time is incorrect.](https://github.com/nebula-contrib/ngbatis/commit/25f63ae280aaaef19d291ceda10741b5a438e5b5)


## [chore: dependencies upgrade](https://github.com/nebula-contrib/ngbatis/commit/a3ab7a1d307dfa7d11189b002d49407679762610)

- nebula-java: 3.6.0 -> 3.8.3
- org.hibernate:hibernate-core was excluded.
> If you need to use hibernate-core, please add the dependency by yourself.



## [feat: support ssl and http2 config in yml.](https://github.com/nebula-contrib/ngbatis/commit/8c8b47b3aadf8c336fb90f45475aa8d37eb407d2)

- example:
    ```yaml
    nebula:
      pool-config:
        enable-ssl: true
        ssl-param:
          sign-mode: SELF_SIGNED
          crt-file-path: /path/to/client.crt
          key-file-path: /path/to/client.key
          password: password
        # ssl-param:
          # sign-mode: CA_SIGNED
          # ca-crt-file-path: /path/to/ca-client.crt
          # crt-file-path: /path/to/client.crt
          # key-file-path: /path/to/client.key
        use-http2: false
        custom-headers:
          Route-Tag: abc
    ```
