### PR TITLE
解决同一点的Tag实体类相互独立时，映射的Object类型可能发生错误的问题

### DIFF
--- a/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
@@ -57,7 +57,7 @@ public class ObjectResultHandler extends AbstractResultHandler<Object, Object> {
 
     for (int i = 0; i < columnNames.size(); i++) {
       ValueWrapper valueWrapper = record.values().get(i);
-      Object v = ResultSetUtil.getValue(valueWrapper);
+      Object v = ResultSetUtil.getValue(valueWrapper,resultType);
       newResult = fillResult(v, newResult, columnNames, resultType, i);
     }
 


### PR DESCRIPTION
关键代码如图，执行 transformNode 的时候传入 resultType ，当 tagType 是 nodeType 的 子类时 才去将 nodeType 换成 tagType 
![image](https://github.com/user-attachments/assets/aa7c64ea-fe2e-4cfe-b841-200b399268c3)
