### PR TITLE
When a node has multiple unassociated tags, it supports specifying tag by specifying the resultType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This source code is licensed under Apache 2.0 License.
 - fix: when `use-session-pool` and spaceFromParam is true, skip the space addition.
 - fix: when timezone is not default, the time is incorrect.
 - fix: allow normal startup without any mapper files.
+- fix: Limit the node type obtained by `selectById` to the entity class of the interface.
 
 ## Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This source code is licensed under Apache 2.0 License.
 - fix: allow normal startup without any mapper files.
 - fix: Limit the node type obtained by `selectById` to the entity class of the interface.
 - fix: When a node has multiple tags, prioritize using the tag of `resultType`. (Collaborate with [charle004](https://github.com/charle004), [#311](https://github.com/nebula-contrib/ngbatis/pull/311))
+- fix: debugging log output issue [#312](https://github.com/nebula-contrib/ngbatis/issues/312)
 
 ## Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This source code is licensed under Apache 2.0 License.
 - fix: when timezone is not default, the time is incorrect.
 - fix: allow normal startup without any mapper files.
 - fix: Limit the node type obtained by `selectById` to the entity class of the interface.
+- fix: When a node has multiple tags, prioritize using the tag of `resultType`. (Collaborate with [charle004](https://github.com/charle004), [#311](https://github.com/nebula-contrib/ngbatis/pull/311))
 
 ## Feature
 

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
@@ -57,7 +57,7 @@ public class ObjectResultHandler extends AbstractResultHandler<Object, Object> {
 
     for (int i = 0; i < columnNames.size(); i++) {
       ValueWrapper valueWrapper = record.values().get(i);
-      Object v = ResultSetUtil.getValue(valueWrapper,resultType);
+      Object v = ResultSetUtil.getValue(valueWrapper, resultType);
       newResult = fillResult(v, newResult, columnNames, resultType, i);
     }
 

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
@@ -57,7 +57,7 @@ public class ObjectResultHandler extends AbstractResultHandler<Object, Object> {
 
     for (int i = 0; i < columnNames.size(); i++) {
       ValueWrapper valueWrapper = record.values().get(i);
-      Object v = ResultSetUtil.getValue(valueWrapper);
+      Object v = ResultSetUtil.getValue(valueWrapper,resultType);
       newResult = fillResult(v, newResult, columnNames, resultType, i);
     }
 

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/MapperProxy.java
@@ -219,9 +219,8 @@ public class MapperProxy {
     try {
       localSession = dispatcher.poll();
       if (log.isDebugEnabled()) {
-        StackTraceElement stackTraceElement = Thread.currentThread().getStackTrace()[6];
-        proxyClass = stackTraceElement.getClassName();
-        proxyMethod = stackTraceElement.getMethodName();
+        proxyClass = cm.getNamespace().getName();
+        proxyMethod = mm.getId();
         localSessionSpace = localSession.getCurrentSpace();
       }
 
@@ -273,9 +272,8 @@ public class MapperProxy {
 
     try {
       if (log.isDebugEnabled()) {
-        StackTraceElement stackTraceElement = Thread.currentThread().getStackTrace()[6];
-        proxyClass = stackTraceElement.getClassName();
-        proxyMethod = stackTraceElement.getMethodName();
+        proxyClass = cm.getNamespace().getName();
+        proxyMethod = mm.getId();
       }
 
       currentSpace = getSpace(cm, mm, paramsForTemplate);

--- a/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/proxy/NebulaDaoBasic.java
@@ -46,6 +46,9 @@ public interface NebulaDaoBasic<T, I extends Serializable> {
    */
   default T selectById(@Param("id") I id) {
     MethodModel methodModel = getMethodModel();
+    Class<?> currentType = this.getClass();
+    Class<?> entityType = entityType(currentType);
+    methodModel.setResultType(entityType);
     ClassModel classModel = getClassModel(this.getClass());
     return (T) MapperProxy.invoke(classModel, methodModel, id);
   }

--- a/src/test/java/org/nebula/contrib/ngbatis/utils/ReflectUtilTest.java
+++ b/src/test/java/org/nebula/contrib/ngbatis/utils/ReflectUtilTest.java
@@ -6,6 +6,8 @@ package org.nebula.contrib.ngbatis.utils;
 
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -23,4 +25,44 @@ public class ReflectUtilTest {
     Assertions.assertTrue(currentTypeOrParentType);
   }
 
+  @Test
+  public void testFindLeafClass() {
+    Set<Class<?>> classes = new HashSet<Class<?>>() {{
+      add(A.class);
+      add(E.class);
+      add(F.class);
+      add(G.class);
+    }};
+    Class<?> leafType = ReflectUtil.findNoForkLeafClass(classes, C.class);
+    Assertions.assertEquals(D.class, leafType);
+
+    leafType = ReflectUtil.findNoForkLeafClass(classes, E.class);
+    Assertions.assertEquals(E.class, leafType);
+
+    leafType = ReflectUtil.findNoForkLeafClass(classes, B.class);
+    Assertions.assertEquals(B.class, leafType);
+  }
 }
+
+/*
+ * - A
+ *   - B
+ *     - C
+ *       - D
+ *         - F
+ *         - G
+ *     - E
+ */
+class A {}
+
+class B extends A {}
+
+class C extends B {}
+
+class D extends C {}
+
+class F extends D {}
+
+class G extends D {}
+
+class E extends B {}


### PR DESCRIPTION
- fix: Limit the node type obtained by `selectById` to the entity class of the interface.
- fix: When a node has multiple tags, prioritize using the tag of `resultType`. (Collaborate with [charle004](https://github.com/charle004), [#311](https://github.com/nebula-contrib/ngbatis/pull/311))
- fix: debugging log output issue [#312](https://github.com/nebula-contrib/ngbatis/issues/312)

close: #310 #312 