### PR TITLE
 @Space property configurable supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,43 @@ This source code is licensed under Apache 2.0 License.
         custom-headers:
           Route-Tag: abc
     ```
+- feat: The @Space annotation supports dynamic configuration.
+> @Space 注解的 name 属性值可通过 spring 配置文件自定义配置，以便多Space场景下灵活配置。
+
+  - example:
+```yml
+app:
+  person:
+    space: PERSON_SPACE
+```
+
+```java
+
+@Space(name = "${app.person.space}")
+@Table(name = "person")
+public class Person {
+    @Id
+    private String vid;
+    private String name;
+
+    public String getVid() {
+        return vid;
+    }
+
+    public void setVid(String vid) {
+        this.vid = vid;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+```
 
 # 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,43 +77,42 @@ This source code is licensed under Apache 2.0 License.
         custom-headers:
           Route-Tag: abc
     ```
-- feat: The @Space annotation supports dynamic configuration.
-> @Space 注解的 name 属性值可通过 spring 配置文件自定义配置，以便多Space场景下灵活配置。
 
+- feat: @Space annotation supports dynamic configuration.
+  > @Space 注解的 name 属性值可通过 spring 配置文件自定义配置。
   - example:
-```yml
-app:
-  person:
-    space: PERSON_SPACE
-```
 
-```java
-
-@Space(name = "${app.person.space}")
-@Table(name = "person")
-public class Person {
-    @Id
-    private String vid;
-    private String name;
-
-    public String getVid() {
-        return vid;
+    ```yaml
+    app:
+      person:
+        space: PERSON_SPACE
+    ```
+  
+    ```java
+    @Space(name = "${nebula.space}")
+    @Table(name = "person")
+    public class Person {
+        @Id
+        private String vid;
+        private String name;
+  
+        public String getVid() {
+            return vid;
+        }
+  
+        public void setVid(String vid) {
+            this.vid = vid;
+        }
+  
+        public String getName() {
+            return name;
+        }
+  
+        public void setName(String name) {
+            this.name = name;
+        }
     }
-
-    public void setVid(String vid) {
-        this.vid = vid;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-}
-
-```
+    ```
 
 # 1.2.2
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,10 @@
             <name>Ozjq</name>
             <email>2719530295@qq.com</email>
         </developer>
+        <developer>
+            <name>charle004</name>
+            <email>937002632@qq.com</email>
+        </developer>
     </developers>
 
     <properties>

--- a/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
@@ -74,7 +74,7 @@ class NgbatisBeanFactoryPostProcessor implements BeanFactoryPostProcessor, Order
   }
 
   public MapperContext mapperContext(NebulaPool nebulaPool) {
-    DaoResourceLoader daoBasicResourceLoader = new DaoResourceLoader(parseCfgProps);
+    DaoResourceLoader daoBasicResourceLoader = new DaoResourceLoader(parseCfgProps,this.context);
     MapperContext context = MapperContext.newInstance();
     context.setResourceRefresh(parseCfgProps.isResourceRefresh());
     context.setNgbatisConfig(nebulaJdbcProperties.getNgbatis());

--- a/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/NgbatisBeanFactoryPostProcessor.java
@@ -74,7 +74,7 @@ class NgbatisBeanFactoryPostProcessor implements BeanFactoryPostProcessor, Order
   }
 
   public MapperContext mapperContext(NebulaPool nebulaPool) {
-    DaoResourceLoader daoBasicResourceLoader = new DaoResourceLoader(parseCfgProps,this.context);
+    DaoResourceLoader daoBasicResourceLoader = new DaoResourceLoader(parseCfgProps, this.context);
     MapperContext context = MapperContext.newInstance();
     context.setResourceRefresh(parseCfgProps.isResourceRefresh());
     context.setNgbatisConfig(nebulaJdbcProperties.getNgbatis());

--- a/src/main/java/org/nebula/contrib/ngbatis/io/DaoResourceLoader.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/io/DaoResourceLoader.java
@@ -16,6 +16,7 @@ import org.jsoup.nodes.TextNode;
 import org.nebula.contrib.ngbatis.config.ParseCfgProps;
 import org.nebula.contrib.ngbatis.exception.ResourceLoadException;
 import org.nebula.contrib.ngbatis.proxy.NebulaDaoBasic;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 
 /**
@@ -29,6 +30,10 @@ public class DaoResourceLoader extends MapperResourceLoader {
 
   public DaoResourceLoader(ParseCfgProps parseConfig) {
     super(parseConfig);
+  }
+
+  public DaoResourceLoader(ParseCfgProps parseConfig, ApplicationContext applicationContext) {
+    super(parseConfig,applicationContext);
   }
 
   /**

--- a/src/main/java/org/nebula/contrib/ngbatis/io/DaoResourceLoader.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/io/DaoResourceLoader.java
@@ -33,7 +33,7 @@ public class DaoResourceLoader extends MapperResourceLoader {
   }
 
   public DaoResourceLoader(ParseCfgProps parseConfig, ApplicationContext applicationContext) {
-    super(parseConfig,applicationContext);
+    super(parseConfig, applicationContext);
   }
 
   /**

--- a/src/main/java/org/nebula/contrib/ngbatis/io/MapperResourceLoader.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/io/MapperResourceLoader.java
@@ -178,7 +178,7 @@ public class MapperResourceLoader extends PathMatchingResourcePatternResolver {
       try {
         resolveResult = applicationContext.getEnvironment().resolveRequiredPlaceholders(value);
       } catch (IllegalArgumentException e) {
-        throw new ResourceLoadException("The name ( "+ value +" ) of annotation @Space missing configurable value");
+        throw new ResourceLoadException("name ( "+ value +" ) of @Space missing configurable value");
       }
     }
     return resolveResult;

--- a/src/main/java/org/nebula/contrib/ngbatis/io/MapperResourceLoader.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/io/MapperResourceLoader.java
@@ -43,6 +43,7 @@ import org.nebula.contrib.ngbatis.utils.Page;
 import org.nebula.contrib.ngbatis.utils.ReflectUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.data.repository.query.Param;
@@ -63,6 +64,7 @@ public class MapperResourceLoader extends PathMatchingResourcePatternResolver {
 
   private static Logger log = LoggerFactory.getLogger(MapperResourceLoader.class);
   protected ParseCfgProps parseConfig;
+  protected ApplicationContext applicationContext;
 
   private MapperResourceLoader() {
     super();
@@ -70,6 +72,11 @@ public class MapperResourceLoader extends PathMatchingResourcePatternResolver {
 
   public MapperResourceLoader(ParseCfgProps parseConfig) {
     this.parseConfig = parseConfig;
+  }
+
+  public MapperResourceLoader(ParseCfgProps parseConfig,ApplicationContext applicationContext) {
+    this.parseConfig = parseConfig;
+    this.applicationContext = applicationContext;
   }
 
   /**
@@ -148,8 +155,18 @@ public class MapperResourceLoader extends PathMatchingResourcePatternResolver {
       }
       String spaceClassName = genericTypes[0].getTypeName();
       Space annotation = Class.forName(spaceClassName).getAnnotation(Space.class);
-      if (null != annotation && !annotation.name().equals("")) {
-        cm.setSpace(annotation.name());
+      if(null != annotation){
+        String spaceName = annotation.name();
+        if (applicationContext!=null) {
+          try {
+            spaceName = applicationContext.getEnvironment().resolveRequiredPlaceholders(spaceName);
+          } catch (IllegalArgumentException e) {
+            throw new ResourceLoadException("The name of annotation @Space in Class "+spaceClassName+" missing configurable value");
+          }
+        }
+        if (!spaceName.equals("")) {
+          cm.setSpace(spaceName);
+        }
       }
     } catch (ClassNotFoundException e) {
       e.printStackTrace();


### PR DESCRIPTION
@Space注解值可通过spring配置文件配置
方法：在获取@Space注解name时，通过Spring的 Environment 对象的 resolveRequiredPlaceholders 方法解析配置，同时也兼容固定name的情况。 
使用示例： @Space(name = "${nebula.secondSpace}") ， spring配置文件中若无 nebula.secondSpace 自定义配置则抛出ResourceLoadException

核心改动：
![image](https://github.com/user-attachments/assets/95dd365d-1df8-41dc-96b8-42e7087ed825)
