### PR TITLE
feat: entity direct query supports specifying different spaces.

### DIFF
--- a/src/main/java/org/nebula/contrib/ngbatis/Env.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/Env.java
@@ -4,11 +4,16 @@ package org.nebula.contrib.ngbatis;
 //
 // This source code is licensed under Apache 2.0 License.
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.nebula.contrib.ngbatis.proxy.MapperProxy.ENV;
+import static org.nebula.contrib.ngbatis.utils.ReflectUtil.spaceFromEntity;
+
 import com.alibaba.fastjson.parser.ParserConfig;
 import com.vesoft.nebula.client.graph.SessionPool;
 import com.vesoft.nebula.client.graph.net.Session;
 import org.nebula.contrib.ngbatis.base.GraphBaseExt;
 import org.nebula.contrib.ngbatis.config.ParseCfgProps;
+import org.nebula.contrib.ngbatis.exception.ResourceLoadException;
 import org.nebula.contrib.ngbatis.models.MapperContext;
 import org.nebula.contrib.ngbatis.proxy.MapperProxy;
 import org.slf4j.Logger;
@@ -122,6 +127,55 @@ public class Env {
     }
   }
 
+  /**
+   * 通过实体类获取对应的space。
+   * 支持占位符，并从配置信息中读取。
+   * 
+   * @param entityType 实体类
+   * @return space
+   */
+  public static String spaceFromConfig(Class<?> entityType) {
+    return spaceFromConfig(entityType, ENV.getContext());
+  }
+
+  public static String spaceFromConfig(Class<?> entityType, ApplicationContext context) {
+    String space = spaceFromEntity(entityType);
+    if (isBlank(space)) return null;
+    space = tryResolvePlaceholder(space, context);
+    return space;
+  }
+  
+  /**
+   * 利用Spring Environment 解析注解的值，用于 @Space 的 name 属性解析
+   * @author <a href="https://github.com/charle004">Charle004</a>
+   * @param value 需要解析的值，可能是带占位符的 ${xx.xx} ，也可以是固定的字符串
+   * @return resolveResult 解析结果
+   * @throws IllegalArgumentException 当配置了 ${xx.xx} 占位符，且spring配置文件中未指定该配置时抛出
+   */
+  public static String tryResolvePlaceholder(String value) {
+    return tryResolvePlaceholder(value, ENV.getContext());
+  }
+
+  /**
+   * 利用Spring Environment 解析注解的值，用于 @Space 的 name 属性解析
+   * @author <a href="https://github.com/charle004">Charle004</a>
+   * @param configKey 需要解析的值，可能是带占位符的 ${xx.xx} ，也可以是固定的字符串
+   * @return resolveResult 解析结果
+   * @throws IllegalArgumentException 当配置了 ${xx.xx} 占位符，且spring配置文件中未指定该配置时抛出
+   */
+  public static String tryResolvePlaceholder(String configKey, ApplicationContext context) {
+    String resolveResult = configKey;
+    if (null != context) {
+      try {
+        resolveResult = context.getEnvironment().resolveRequiredPlaceholders(configKey);
+      } catch (IllegalArgumentException e) {
+        throw new ResourceLoadException(
+          "name ( " + configKey + " ) of @Space missing configurable value"
+        );
+      }
+    }
+    return resolveResult;
+  }
 
   public String getUsername() {
     return username;

--- a/src/main/java/org/nebula/contrib/ngbatis/base/GraphBase.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/base/GraphBase.java
@@ -1,6 +1,7 @@
 package org.nebula.contrib.ngbatis.base;
 
 import java.util.Map;
+import org.nebula.contrib.ngbatis.models.MapperContext;
 
 /**
  * 实体基类
@@ -9,6 +10,10 @@ import java.util.Map;
  */
 
 public abstract class GraphBase {
+  public GraphBase() {
+    Map<String, Class<?>> tagTypeMapping = MapperContext.newInstance().getTagTypeMapping();
+    tagTypeMapping.put(getEntityTypeName(), this.getClass());
+  }
 
   protected abstract String getEntityTypeName();
 

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
@@ -24,6 +24,7 @@ import javax.persistence.Column;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import org.nebula.contrib.ngbatis.annotations.Space;
 import org.nebula.contrib.ngbatis.annotations.base.EdgeType;
 import org.nebula.contrib.ngbatis.annotations.base.GraphId;
 import org.nebula.contrib.ngbatis.annotations.base.Tag;
@@ -623,4 +624,25 @@ public abstract class ReflectUtil {
     }
     return false;
   }
+
+  /**
+   * 从实体类获取 space，并解析占位符
+    */
+  public static String spaceFromEntity(Class<?> entityType) {
+    boolean hasSpace = entityType.isAnnotationPresent(Space.class);
+    String space = null;
+    if (hasSpace) {
+      Space spaceAnnotation = entityType.getAnnotation(Space.class);
+      space = spaceAnnotation.name();
+    }
+    
+    boolean hasTable = entityType.isAnnotationPresent(Table.class);
+    if (hasTable) {
+      Table tableAnnotation = entityType.getAnnotation(Table.class);
+      space = tableAnnotation.schema();
+    }
+    
+    return space;
+  }
+  
 }


### PR DESCRIPTION
as title: 
zh: 为数据对象直接查询的功能，提供在实体注解中指定不同space的支持：

```java
// Both are acceptable. The priority is: Space > Table
// 两种都行，优先级：Space > Table
@Space("test") 
@Table(name = "player", schema="test")
public class Player extends GraphBaseVertex {
  // ...
}
```

```java
@Space("${nebula.space}") // from yml or configuration center
@Table(name = "player", schema="${nebula.space}")
public class Player extends GraphBaseVertex {
  // ...
}
```
