### PR TITLE
fix the mapping issue of `Byte` and `Duration`

### DIFF
--- a/CHANGELOG-CN.md
+++ b/CHANGELOG-CN.md
@@ -5,6 +5,25 @@ Copyright (c) 2024 All project authors and nebula-contrib. All rights reserved.
 This source code is licensed under Apache 2.0 License.
 -->
 
+# NEXT
+
+## Bugfix
+
+- fix [#63](https://github.com/nebula-contrib/ngbatis/pull/63): 在 ASM 生成代理类时，自动计算方法的最大栈深及局部变量表个数。 来自: [@moroyimk](https://github.com/moroyimk)
+- fix: 修复自定义 xml 中， `Duration` 作为属性类型不被支持的问题
+- revert: 回退关于 2.0.0-beta.1 的修改。
+  > 为兼容 `${ ng.valueFmt( value ) }`, 当 value 为 null 时，依然可以输出占位符，可使用以下方式
+  >
+    > ```beetl
+    > ${ ng.valueFmt( value ) ! "null" }
+    > ```
+  >
+- fix: 修复字段属性为 Byte 时，不能正常解析到实体对象的问题。
+
+## Upgrade
+
+- upgrade: 升级 fastjson 版本至 2.0.57.
+
 # 2.0.0-beta.1
 
 ## Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ This source code is licensed under Apache 2.0 License.
 
 # NEXT
 
+## Bugfix
+
+- fix ([#63](https://github.com/nebula-contrib/ngbatis/pull/63): automatically calculating stack and local variables in asm. via: [@moroyimk](https://github.com/moroyimk)
+- fix: fix the issue of `Duration` type in custom xml
+- revert: revert the change of 2.0.0-beta.1
+  > To be compatible with `${ ng.valueFmt( value ) }`, when value is null, it can still output a placeholder. You can use the following method:
+  >
+    > ```beetl
+    > ${ ng.valueFmt( value ) ! "null" }
+    > ```
+  >
+- fix: fix the issue of field type is Byte, cannot be parsed to entity object.
+
+## Upgrade
+
+- upgrade: upgrade fastjson version to 2.0.57.
+
 # 2.0.0-beta.1
 
 ## Bugfix

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/pojo/AllFieldTypes.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/pojo/AllFieldTypes.java
@@ -1,0 +1,224 @@
+package ye.weicheng.ngbatis.demo.pojo;
+
+// Copyright (c) 2025 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.util.Objects;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.springframework.format.annotation.DateTimeFormat;
+
+/**
+ * @author yeweicheng
+ * @since 2025-05-07 2:49
+ * <br>Now is history!
+ */
+@Table(name = "all_field_types")
+public class AllFieldTypes {
+  
+  @Id
+  private String id;
+  private Long aLong;
+  private Boolean aBoolean;
+  private String aString;
+  private Double aDouble;
+  private Integer anInt;
+  private Short aShort;
+  private Byte aByte;
+  private Float aFloat;
+  private java.sql.Date aDate;
+  private java.sql.Time aTime;
+  @DateTimeFormat( pattern = "yyyy-MM-dd'T'HH:mm:ss" )
+  private java.util.Date aDateTime;
+  private java.sql.Timestamp aTimestamp;
+  private Duration aDuration;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    AllFieldTypes that = (AllFieldTypes) o;
+
+    if (!Objects.equals(id, that.id)) {
+      return false;
+    }
+    if (!Objects.equals(aLong, that.aLong)) {
+      return false;
+    }
+    if (!Objects.equals(aBoolean, that.aBoolean)) {
+      return false;
+    }
+    if (!Objects.equals(aString, that.aString)) {
+      return false;
+    }
+    if (!Objects.equals(aDouble, that.aDouble)) {
+      return false;
+    }
+    if (!Objects.equals(anInt, that.anInt)) {
+      return false;
+    }
+    if (!Objects.equals(aShort, that.aShort)) {
+      return false;
+    }
+    if (!Objects.equals(aByte, that.aByte)) {
+      return false;
+    }
+    if (!Objects.equals(aFloat, that.aFloat)) {
+      return false;
+    }
+    if (!Objects.equals(aDate, that.aDate)) {
+      return false;
+    }
+    if (!Objects.equals(aTime, that.aTime)) {
+      return false;
+    }
+    if (!Objects.equals(aDateTime, that.aDateTime)) {
+      return false;
+    }
+    if (!Objects.equals(aTimestamp, that.aTimestamp)) {
+      return false;
+    }
+    return Objects.equals(aDuration, that.aDuration);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (aLong != null ? aLong.hashCode() : 0);
+    result = 31 * result + (aBoolean != null ? aBoolean.hashCode() : 0);
+    result = 31 * result + (aString != null ? aString.hashCode() : 0);
+    result = 31 * result + (aDouble != null ? aDouble.hashCode() : 0);
+    result = 31 * result + (anInt != null ? anInt.hashCode() : 0);
+    result = 31 * result + (aShort != null ? aShort.hashCode() : 0);
+    result = 31 * result + (aByte != null ? aByte.hashCode() : 0);
+    result = 31 * result + (aFloat != null ? aFloat.hashCode() : 0);
+    result = 31 * result + (aDate != null ? aDate.hashCode() : 0);
+    result = 31 * result + (aTime != null ? aTime.hashCode() : 0);
+    result = 31 * result + (aDateTime != null ? aDateTime.hashCode() : 0);
+    result = 31 * result + (aTimestamp != null ? aTimestamp.hashCode() : 0);
+    result = 31 * result + (aDuration != null ? aDuration.hashCode() : 0);
+    return result;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Long getaLong() {
+    return aLong;
+  }
+
+  public void setaLong(Long aLong) {
+    this.aLong = aLong;
+  }
+
+  public Boolean getaBoolean() {
+    return aBoolean;
+  }
+
+  public void setaBoolean(Boolean aBoolean) {
+    this.aBoolean = aBoolean;
+  }
+
+  public String getaString() {
+    return aString;
+  }
+
+  public void setaString(String aString) {
+    this.aString = aString;
+  }
+
+  public Double getaDouble() {
+    return aDouble;
+  }
+
+  public void setaDouble(Double aDouble) {
+    this.aDouble = aDouble;
+  }
+
+  public Integer getAnInt() {
+    return anInt;
+  }
+
+  public void setAnInt(Integer anInt) {
+    this.anInt = anInt;
+  }
+
+  public Short getaShort() {
+    return aShort;
+  }
+
+  public void setaShort(Short aShort) {
+    this.aShort = aShort;
+  }
+
+  public Byte getaByte() {
+    return aByte;
+  }
+
+  public void setaByte(Byte aByte) {
+    this.aByte = aByte;
+  }
+
+  public Float getaFloat() {
+    return aFloat;
+  }
+
+  public void setaFloat(Float aFloat) {
+    this.aFloat = aFloat;
+  }
+
+  public Date getaDate() {
+    return aDate;
+  }
+
+  public void setaDate(Date aDate) {
+    this.aDate = aDate;
+  }
+
+  public Time getaTime() {
+    return aTime;
+  }
+
+  public void setaTime(Time aTime) {
+    this.aTime = aTime;
+  }
+
+  public java.util.Date getaDateTime() {
+    return aDateTime;
+  }
+
+  public void setaDateTime(java.util.Date aDateTime) {
+    this.aDateTime = aDateTime;
+  }
+
+  public Timestamp getaTimestamp() {
+    return aTimestamp;
+  }
+
+  public void setaTimestamp(Timestamp aTimestamp) {
+    this.aTimestamp = aTimestamp;
+  }
+
+  public Duration getaDuration() {
+    return aDuration;
+  }
+
+  public void setaDuration(Duration aDuration) {
+    this.aDuration = aDuration;
+  }
+}

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/AllFieldTypesDao.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/AllFieldTypesDao.java
@@ -1,0 +1,18 @@
+package ye.weicheng.ngbatis.demo.repository;
+
+// Copyright (c) 2025 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import ye.weicheng.ngbatis.demo.pojo.AllFieldTypes;
+
+/**
+ * @author yeweicheng
+ * @since 2025-05-07 3:43
+ * <br>Now is history!
+ */
+public interface AllFieldTypesDao {
+  
+  AllFieldTypes testValueFmt(AllFieldTypes fieldTypes);
+
+}

--- a/ngbatis-demo/src/main/resources/mapper/AllFieldTypesDao.xml
+++ b/ngbatis-demo/src/main/resources/mapper/AllFieldTypesDao.xml
@@ -1,0 +1,39 @@
+<!--
+    Copyright (c) 2025 All project authors. All rights reserved.
+    
+    This source code is licensed under Apache 2.0 License.
+-->
+<mapper namespace="ye.weicheng.ngbatis.demo.repository.AllFieldTypesDao" space="test">
+<!--
+  private Long aLong;
+  private Boolean aBoolean;
+  private String aString;
+  private String aDouble;
+  private Integer anInt;
+  private Short aShort;
+  private Byte aByte;
+  private Float aFloat;
+  private java.sql.Date aDate;
+  private java.sql.Time aTime;
+  private java.util.Date aDateTime;
+  private java.sql.Timestamp aTimestamp;
+  private Duration aDuration;
+-->
+  <select id="testValueFmt" resultType="ye.weicheng.ngbatis.demo.pojo.AllFieldTypes">
+    RETURN 
+      ${ ng.valueFmt(aLong)!"null" } as aLong,
+      ${ ng.valueFmt(aBoolean)!"null" } as aBoolean,
+      ${ ng.valueFmt(aString)!"null" } as aString,
+      ${ ng.valueFmt(aDouble)!"null" } as aDouble,
+      ${ ng.valueFmt(anInt)!"null" } as anInt,
+      ${ ng.valueFmt(aShort)!"null" } as aShort,
+      ${ ng.valueFmt(aByte)!"null" } as aByte,
+      ${ ng.valueFmt(aFloat)!"null" } as aFloat,
+      ${ ng.valueFmt(aDate)!"null" } as aDate,
+      ${ ng.valueFmt(aTime)!"null" } as aTime,
+      ${ ng.valueFmt(aDateTime)!"null" } as aDateTime,
+      ${ ng.valueFmt(aTimestamp)!"null" } as aTimestamp,
+      ${ ng.valueFmt(aDuration)!"null" } as aDuration;
+  </select>
+  
+</mapper>

--- a/ngbatis-demo/src/main/resources/mapper/TestRepository.xml
+++ b/ngbatis-demo/src/main/resources/mapper/TestRepository.xml
@@ -177,7 +177,7 @@
     </select>
   
     <select id="testValueFmtWhenNull">
-        RETURN ${ ng.valueFmt(value) }
+        RETURN ${ ng.valueFmt(value) ! "null" }
     </select>
 
 </mapper>

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/AllFieldTypesDaoTest.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/AllFieldTypesDaoTest.java
@@ -1,0 +1,60 @@
+package ye.weicheng.ngbatis.demo.repository;
+
+// Copyright (c) 2025 All project authors. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+import static org.springframework.util.ObjectUtils.nullSafeEquals;
+
+import com.alibaba.fastjson.JSON;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.Assert;
+import ye.weicheng.ngbatis.demo.pojo.AllFieldTypes;
+
+/**
+ * @author yeweicheng
+ * @since 2025-05-07 3:48
+ * <br>Now is history!
+ */
+@SpringBootTest
+@TestMethodOrder(OrderAnnotation.class)
+class AllFieldTypesDaoTest {
+  
+  @Autowired private AllFieldTypesDao dao;
+
+  @Test
+  void testValueFmt() {
+    AllFieldTypes allFieldTypes = new AllFieldTypes();
+    allFieldTypes.setaLong(1L);
+    allFieldTypes.setaBoolean(true);
+    allFieldTypes.setaString("aString");
+    allFieldTypes.setaDouble(1.0);
+    allFieldTypes.setAnInt(1);
+    allFieldTypes.setaShort((short) 1);
+    allFieldTypes.setaByte((byte) 1);
+    allFieldTypes.setaFloat(1.0f);
+    allFieldTypes.setaDate(new java.sql.Date(System.currentTimeMillis()));
+    allFieldTypes.setaTime(new java.sql.Time(System.currentTimeMillis()));
+    allFieldTypes.setaDateTime(new java.util.Date(System.currentTimeMillis()));
+    allFieldTypes.setaTimestamp(new java.sql.Timestamp(System.currentTimeMillis()));
+    allFieldTypes.setaDuration(java.time.Duration.ofSeconds(1));
+
+    AllFieldTypes allFieldTypesFromDb = dao.testValueFmt(allFieldTypes);
+    System.out.println(JSON.toJSONString(allFieldTypes));
+    System.out.println(JSON.toJSONString(allFieldTypesFromDb));
+    System.out.println(allFieldTypesFromDb.equals(allFieldTypes)); // 两个对象不相等，因为时间精度失真
+  }
+
+  @Test
+  void testValueFmtAllNull() {
+    AllFieldTypes allFieldTypes = new AllFieldTypes();
+    AllFieldTypes allFieldTypesFromDb = dao.testValueFmt(allFieldTypes);
+    System.out.println(JSON.toJSONString(allFieldTypesFromDb));
+    System.out.println(JSON.toJSONString(allFieldTypesFromDb));
+    Assert.isTrue(nullSafeEquals(allFieldTypesFromDb, allFieldTypes), "two var should be equal!"); // 断言两个对象相等
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.83</version>
+            <version>2.0.57</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>

--- a/src/main/java/org/nebula/contrib/ngbatis/Env.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/Env.java
@@ -25,11 +25,6 @@ public class Env {
 
   public static ClassLoader classLoader;
 
-  // 使用 fastjson 安全模式，规避任意代码执行风险
-  static {
-    ParserConfig.getGlobalInstance().setSafeMode(true);
-  }
-
   private Logger log = LoggerFactory.getLogger(Env.class);
 
   //  private SessionFactory sessionFactory;

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/DefaultArgsResolver.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/DefaultArgsResolver.java
@@ -69,8 +69,8 @@ public class DefaultArgsResolver implements ArgsResolver {
       put(Integer.class, (Setter<Integer>) Value::iVal);
       put(short.class, (Setter<Short>) Value::iVal);
       put(Short.class, (Setter<Short>) Value::iVal);
-      put(byte.class, (Setter<Short>) Value::iVal);
-      put(Byte.class, (Setter<Short>) Value::iVal);
+      put(byte.class, (Setter<Byte>) Value::iVal);
+      put(Byte.class, (Setter<Byte>) Value::iVal);
       put(long.class, (Setter<Long>) Value::iVal);
       put(Long.class, (Setter<Long>) Value::iVal);
       put(float.class, (Setter<Float>) Value::fVal);

--- a/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/ValueFmtFn.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/binding/beetl/functions/ValueFmtFn.java
@@ -41,7 +41,7 @@ public class ValueFmtFn extends AbstractFunction<Object, Boolean, Boolean, Void,
     ifStringLike = ifStringLike != null && ifStringLike;
     escape = escape != null ? escape : ValueFmtFn.escape;
     if (value == null) {
-      return "null";
+      return null;
     }
     if (value instanceof String) {
       value = (escape ? StringEscapeUtils.escapeJava((String) value) : value);


### PR DESCRIPTION
### Bugfix

- fix: fix the issue of `Duration` type in custom xml
- revert: revert the change of 2.0.0-beta.1
  > To be compatible with `${ ng.valueFmt( value ) }`, when value is null, it can still output a placeholder. You can use the following method:
  >
    > ```beetl
    > ${ ng.valueFmt( value ) ! "null" }
    > ```
  >
- fix: fix the issue of field type is Byte, cannot be parsed to entity object.

### Upgrade

- upgrade: upgrade fastjson version to 2.0.57.


<details>
  <summary><h2> 详情</h2></summary>

### Bugfix

- fix: 修复自定义 xml 中， `Duration` 作为属性类型不被支持的问题
- revert: 回退关于 2.0.0-beta.1 的修改。
  > 为兼容 `${ ng.valueFmt( value ) }`, 当 value 为 null 时，依然可以输出占位符，可使用以下方式
  >
    > ```beetl
    > ${ ng.valueFmt( value ) ! "null" }
    > ```
  >
- fix: 修复字段属性为 Byte 时，不能正常解析到实体对象的问题。

### Upgrade

- upgrade: 升级 fastjson 版本至 2.0.57.
</details>