### PR TITLE
feat: support props can be directly mapped to entity objects.

### DIFF
--- a/CHANGELOG-CN.md
+++ b/CHANGELOG-CN.md
@@ -20,6 +20,31 @@ This source code is licensed under Apache 2.0 License.
   >
 - fix: 修复字段属性为 Byte 时，不能正常解析到实体对象的问题。
 
+## 新特性
+
+- 支持节点的属性对象字段可以与实体对象直接映射
+
+  ```java
+  @Table(name = "column_alias")
+  public class ColumnAlias {
+    @Id @Column(name = "id_no") private String idNo;
+    @Column(name = "first_name") private String firstName;
+    @Column(name = "last_name") private String lastName;
+    @Transient private String ignoreMe;
+  }
+  ```
+
+  ```xml
+  <select id="propsToObj">
+    MATCH (n :column_alias)
+    WHERE n.column_alias.first_name is not null
+    RETURN
+      properties(n),
+      "ignoreMe" as ignoreMe
+    LIMIT 1
+  </select>
+  ```
+
 ## Upgrade
 
 - upgrade: 升级 fastjson 版本至 2.0.57.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,31 @@ This source code is licensed under Apache 2.0 License.
   >
 - fix: fix the issue of field type is Byte, cannot be parsed to entity object.
 
+## Feature
+
+- Supporting props can be directly mapped to entity objects.
+
+  ```java
+  @Table(name = "column_alias")
+  public class ColumnAlias {
+    @Id @Column(name = "id_no") private String idNo;
+    @Column(name = "first_name") private String firstName;
+    @Column(name = "last_name") private String lastName;
+    @Transient private String ignoreMe;
+  }
+  ```
+
+  ```xml
+  <select id="propsToObj">
+    MATCH (n :column_alias)
+    WHERE n.column_alias.first_name is not null
+    RETURN
+      properties(n),
+      "ignoreMe" as ignoreMe
+    LIMIT 1
+  </select>
+  ```
+
 ## Upgrade
 
 - upgrade: upgrade fastjson version to 2.0.57.

--- a/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/ColumnAliasDao.java
+++ b/ngbatis-demo/src/main/java/ye/weicheng/ngbatis/demo/repository/ColumnAliasDao.java
@@ -15,4 +15,6 @@ import ye.weicheng.ngbatis.demo.pojo.ColumnAlias;
  */
 public interface ColumnAliasDao extends NebulaDaoBasic<ColumnAlias, String> {
 
+  ColumnAlias propsToObj();
+
 }

--- a/ngbatis-demo/src/main/resources/application.yml
+++ b/ngbatis-demo/src/main/resources/application.yml
@@ -13,6 +13,13 @@ nebula:
     # default false(false: Session pool map will not be initialized)
     use-session-pool: true
     test-space-placeholder: cmqa
+    # 是否启用 props 作为栏位时，直接映射到实体对象的属性。
+    # 会改变原有的映射方式。请检查是否影响原有业务逻辑。
+    # 如果对原有业务产生影响，请设置为 false
+    # Whether to enable props as fields directly mapped to entity objects. 
+    # It will change the original mapping method. Please check whether it affects the original business logic.
+    # If it affects the original business, please set it to false
+    enable-prop-mapping: true
   hosts: 139.9.187.207:9669
   username: root
   password: U3RhclNoYWRvd18wOTE5

--- a/ngbatis-demo/src/main/resources/mapper/ColumnAliasDao.xml
+++ b/ngbatis-demo/src/main/resources/mapper/ColumnAliasDao.xml
@@ -5,4 +5,13 @@
 -->
 <mapper namespace="ye.weicheng.ngbatis.demo.repository.ColumnAliasDao" space="test">
   
+  <select id="propsToObj">
+    MATCH (n :column_alias)
+    WHERE n.column_alias.first_name is not null
+    RETURN
+      properties(n),
+      "ignoreMe" as ignoreMe
+    LIMIT 1
+  </select>
+  
 </mapper>

--- a/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/ColumnAliasDaoTest.java
+++ b/ngbatis-demo/src/test/java/ye/weicheng/ngbatis/demo/repository/ColumnAliasDaoTest.java
@@ -4,6 +4,7 @@ package ye.weicheng.ngbatis.demo.repository;
 //
 // This source code is licensed under Apache 2.0 License.
 
+import com.alibaba.fastjson.JSON;
 import java.util.List;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -98,6 +99,14 @@ public class ColumnAliasDaoTest {
     colAliasPojo.setFirstName(query);
     List<String> idsInDb = dao.selectIdBySelectiveStringLike(colAliasPojo);
     Assert.isTrue(idsInDb.contains(idNo));
+  }
+  
+  @Test
+  @Order(8)
+  public void testPropsToObj() {
+    ColumnAlias alias = dao.propsToObj();
+    System.out.println(JSON.toJSONString(alias));
+    Assert.isTrue(alias == null || alias.getFirstName() != null);
   }
   
   @Test

--- a/src/main/java/org/nebula/contrib/ngbatis/NgbatisContextInitializer.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/NgbatisContextInitializer.java
@@ -165,6 +165,9 @@ public class NgbatisContextInitializer implements ApplicationContextInitializer 
             )
             .setUseSessionPool(
               environment.getProperty("nebula.ngbatis.use-session-pool", Boolean.class)
+            )
+            .setEnablePropMapping(
+              environment.getProperty("nebula.ngbatis.enable-prop-mapping", Boolean.class)
             );
   }
 

--- a/src/main/java/org/nebula/contrib/ngbatis/config/NgbatisConfig.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/config/NgbatisConfig.java
@@ -26,6 +26,11 @@ public class NgbatisConfig {
    */
   public Boolean useSessionPool;
 
+  /**
+   * Whether enable direct mapping of props to object
+   * @return true/false
+   */
+  public Boolean enablePropMapping;
 
   public Long getSessionLifeLength() {
     return sessionLifeLength;
@@ -77,6 +82,23 @@ public class NgbatisConfig {
     }
     this.useSessionPool = useSessionPool;
     return this;
+  }
 
+  public Boolean getEnablePropMapping() {
+    return enablePropMapping;
+  }
+
+  /**
+   * 默认 false
+   * @param enablePropMapping 是否启用 props 作为栏位时，直接映射到实体对象的属性
+   * @return true/false
+   */
+  public NgbatisConfig setEnablePropMapping(Boolean enablePropMapping) {
+    if (enablePropMapping == null) {
+      this.enablePropMapping = true;
+      return this;
+    }
+    this.enablePropMapping = enablePropMapping;
+    return this;
   }
 }

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
@@ -12,7 +12,14 @@ import com.vesoft.nebula.client.graph.data.Node;
 import com.vesoft.nebula.client.graph.data.Relationship;
 import com.vesoft.nebula.client.graph.data.ResultSet;
 import com.vesoft.nebula.client.graph.data.ValueWrapper;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.nebula.contrib.ngbatis.utils.ReflectUtil;
 import org.nebula.contrib.ngbatis.utils.ResultSetUtil;
 import org.springframework.stereotype.Component;
@@ -28,6 +35,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class ObjectResultHandler extends AbstractResultHandler<Object, Object> {
 
+  final private Map<Class<?>, Field[]> classDeclaredFieldsMap = new HashMap<>();
+  final private Map<Class<?>, Field[]> classAllDeclaredFieldsMap = new HashMap<>();
+  final private Map<Class<?>, Set<?>> classColumnNamesMap = new HashMap<>();
+  final private Map<Class<?>, Set<?>> classAllColumnNamesMap = new HashMap<>();
+  
   @Override
   public Object handle(Object newResult, ResultSet result, Class resultType)
       throws NoSuchFieldException, IllegalAccessException {
@@ -86,10 +98,57 @@ public class ObjectResultHandler extends AbstractResultHandler<Object, Object> {
         resultType,
         columnName
       );
+    } else if (valIsProps(v, resultType)) {
+      Map<?, ?> props = (Map<?, ?>) v;
+      Set<?> allColumn = computeAllColumn(resultType);
+      Set<?> retains = new HashSet<>(props.keySet());
+      retains.retainAll(allColumn);
+      for (Object o : retains) {
+        String k = String.valueOf(o);
+        Object prop = props.get(k);
+        ReflectUtil.setValue(newResult, k, prop);
+      }
     } else {
       ReflectUtil.setValue(newResult, columnName, v);
     }
     return newResult;
+  }
+  
+  private boolean valIsProps(Object v, Class<?> resultType) {
+    // 从属性获取的一个前提是，栏位值本身是一个map
+    if (v instanceof Map) {
+      Map<?, ?> m = (Map<?, ?>) v;
+      Set<?> columnNames = computeColumnNames(resultType);
+      return m.keySet().containsAll(columnNames);
+    }
+    return false;
+  }
+  
+  private Set<?> computeAllColumn(Class<?> resultType) {
+    Field[] fs = classAllDeclaredFieldsMap.computeIfAbsent(
+      resultType,
+      (k) -> ReflectUtil.getAllColumnFields(k, true)
+    );
+
+    return classAllColumnNamesMap.computeIfAbsent(
+      resultType,
+      (k) -> Arrays.stream(fs)
+        .map(ReflectUtil::getNameByColumn)
+        .collect(Collectors.toSet())
+    );
+  }
+  
+  private Set<?> computeColumnNames(Class<?> resultType) {
+    Field[] fs = classDeclaredFieldsMap.computeIfAbsent(
+      resultType,
+      (k) -> ReflectUtil.getColumnFields(k, true)
+    );
+    return classColumnNamesMap.computeIfAbsent(
+      resultType,
+      (k) -> Arrays.stream(fs)
+        .map(ReflectUtil::getNameByColumn)
+        .collect(Collectors.toSet())
+    );
   }
 
   private boolean valIsResultType(Object v, Class resultType) {

--- a/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/handler/ObjectResultHandler.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.nebula.contrib.ngbatis.config.NgbatisConfig;
+import org.nebula.contrib.ngbatis.models.MapperContext;
 import org.nebula.contrib.ngbatis.utils.ReflectUtil;
 import org.nebula.contrib.ngbatis.utils.ResultSetUtil;
 import org.springframework.stereotype.Component;
@@ -115,6 +117,8 @@ public class ObjectResultHandler extends AbstractResultHandler<Object, Object> {
   }
   
   private boolean valIsProps(Object v, Class<?> resultType) {
+    NgbatisConfig ngbatisConfig = MapperContext.newInstance().getNgbatisConfig();
+    if (!ngbatisConfig.getEnablePropMapping()) return false;
     // 从属性获取的一个前提是，栏位值本身是一个map
     if (v instanceof Map) {
       Map<?, ?> m = (Map<?, ?>) v;

--- a/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
+++ b/src/main/java/org/nebula/contrib/ngbatis/utils/ReflectUtil.java
@@ -25,6 +25,8 @@ import javax.persistence.Column;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import org.nebula.contrib.ngbatis.annotations.DstId;
+import org.nebula.contrib.ngbatis.annotations.SrcId;
 import org.nebula.contrib.ngbatis.annotations.base.EdgeType;
 import org.nebula.contrib.ngbatis.annotations.base.Tag;
 import org.nebula.contrib.ngbatis.exception.ParseException;
@@ -445,6 +447,24 @@ public abstract class ReflectUtil {
       clazz = clazz.getSuperclass();
     } while (clazz != null);
     return fields.toArray(new Field[0]);
+  }
+
+  /**
+   * 获取当前类的所有属性
+   * @param clazz
+   * @param forValueSetting
+   * @return
+   */
+  public static Field[] getColumnFields(Class<?> clazz, boolean forValueSetting) {
+    Field[] allColumnFields = getAllColumnFields(clazz, forValueSetting);
+    return Arrays.stream(allColumnFields)
+      .filter(el -> el.isAnnotationPresent(Column.class) 
+        && !el.isAnnotationPresent(Id.class)
+        && !el.isAnnotationPresent(DstId.class) 
+        && !el.isAnnotationPresent(SrcId.class)
+        && (!el.isAnnotationPresent(Transient.class) || forValueSetting)
+      )
+      .toArray(Field[]::new);
   }
 
 


### PR DESCRIPTION
- Example:

  ```java
  @Table(name = "column_alias")
  public class ColumnAlias {
    @Id @Column(name = "id_no") private String idNo;
    @Column(name = "first_name") private String firstName;
    @Column(name = "last_name") private String lastName;
    @Transient private String ignoreMe;
  }
  ```

  ```xml
  <select id="propsToObj">
    MATCH (n :column_alias)
    WHERE n.column_alias.first_name is not null
    RETURN
      properties(n),
      "ignoreMe" as ignoreMe
    LIMIT 1
  </select>
  ```