### PR TITLE
fix: use Maven Shade plugin to relocate fastjson2 package in ngbatis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,39 @@
                 </configuration>
             </plugin>
 
+            <!-- Maven Shade Plugin - 重命名 fastjson2 包名 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.alibaba.fastjson2</pattern>
+                                    <shadedPattern>org.nebula.contrib.ngbatis.internal.fastjson2</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- compiler -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- Relocate 'com.alibaba.fastjson2' to 'org.nebula.contrib.ngbatis.internal.fastjson2' using Maven Shade plugin during build

- This avoids classpath conflicts between fastjson2 (used internally) and fastjson1 which is commonly used in dependent projects

- Enables ngbatis to be integrated safely in environments where both fastjson versions coexist without breaking compatibility or causing runtime errors

- Addresses issue with fastjson version clashes reported by users